### PR TITLE
Stabilize install state and add advanced profiles

### DIFF
--- a/app/src/main/cpp/native_probe.c
+++ b/app/src/main/cpp/native_probe.c
@@ -250,3 +250,39 @@ Java_dev_busung_s25uroot_NativeProbe_run(JNIEnv *env, jobject thiz) {
 
   return (*env)->NewStringUTF(env, output);
 }
+
+JNIEXPORT jboolean JNICALL
+Java_dev_busung_s25uroot_NativeProbe_isKernelSuActive(JNIEnv *env,
+                                                       jobject thiz) {
+  (void)env;
+  (void)thiz;
+
+  if (access("/sys/module/kernelsu", F_OK) == 0) {
+    return JNI_TRUE;
+  }
+
+  int fd = open("/proc/modules", O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    return JNI_FALSE;
+  }
+
+  char modules[65536];
+  ssize_t count = read(fd, modules, sizeof(modules) - 1);
+  close(fd);
+  if (count <= 0) {
+    return JNI_FALSE;
+  }
+  modules[count] = '\0';
+
+  const char *line = modules;
+  while (line != NULL && *line != '\0') {
+    if (strncmp(line, "kernelsu ", sizeof("kernelsu ") - 1) == 0) {
+      return JNI_TRUE;
+    }
+    line = strchr(line, '\n');
+    if (line != NULL) {
+      ++line;
+    }
+  }
+  return JNI_FALSE;
+}

--- a/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
@@ -32,6 +32,8 @@ object AppPreferences {
     private const val PREFERENCES = "appearance"
     private const val ACCENT_COLOR = "accent_color"
     private const val THEME_MODE = "theme_mode"
+    private const val ADVANCED_MODE = "advanced_mode"
+    private const val CONSUMED_INSTALL_REQUEST = "consumed_install_request"
 
     fun accentColor(context: Context): AccentColor = AccentColor.fromStoredValue(
         context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
@@ -55,6 +57,27 @@ object AppPreferences {
             .edit()
             .putString(THEME_MODE, themeMode.storedValue)
             .apply()
+    }
+
+    fun advancedMode(context: Context): Boolean =
+        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+            .getBoolean(ADVANCED_MODE, false)
+
+    fun setAdvancedMode(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(ADVANCED_MODE, enabled)
+            .apply()
+    }
+
+    @Synchronized
+    fun consumeInstallRequest(context: Context, requestId: String?): Boolean {
+        if (requestId.isNullOrBlank()) return false
+        val preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+        if (preferences.getString(CONSUMED_INSTALL_REQUEST, null) == requestId) return false
+        return preferences.edit()
+            .putString(CONSUMED_INSTALL_REQUEST, requestId)
+            .commit()
     }
 
     fun languageTag(context: Context): String {

--- a/app/src/main/java/dev/busung/s25uroot/InstallActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallActivity.kt
@@ -63,6 +63,12 @@ class InstallActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        val profileId = intent.getStringExtra(EXTRA_PROFILE_ID)
+        val startInstall = savedInstanceState == null && AppPreferences.consumeInstallRequest(
+            this,
+            intent.getStringExtra(EXTRA_INSTALL_REQUEST_ID),
+        )
+        intent.removeExtra(EXTRA_INSTALL_REQUEST_ID)
         setContent {
             RootMyGalaxyTheme(
                 accentColor = AppPreferences.accentColor(this),
@@ -70,14 +76,12 @@ class InstallActivity : ComponentActivity() {
             ) {
                 val installState by installViewModel.state.collectAsStateWithLifecycle()
                 BackHandler(enabled = installState.busy) {}
-                LaunchedEffect(Unit) {
-                    if (intent.getBooleanExtra(EXTRA_START_INSTALL, false)) {
-                        installViewModel.install()
-                    }
+                LaunchedEffect(startInstall, profileId) {
+                    if (startInstall) installViewModel.install(profileId)
                 }
                 InstallScreen(
                     installState = installState,
-                    onRetry = installViewModel::install,
+                    onRetry = { installViewModel.install(profileId) },
                     onClose = ::finish,
                 )
             }
@@ -85,7 +89,8 @@ class InstallActivity : ComponentActivity() {
     }
 
     companion object {
-        const val EXTRA_START_INSTALL = "start_install"
+        const val EXTRA_INSTALL_REQUEST_ID = "install_request_id"
+        const val EXTRA_PROFILE_ID = "profile_id"
     }
 }
 

--- a/app/src/main/java/dev/busung/s25uroot/InstallHistory.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallHistory.kt
@@ -1,10 +1,9 @@
 package dev.busung.s25uroot
 
 import android.content.Context
+import android.util.AtomicFile
 import org.json.JSONObject
 import java.io.File
-import java.nio.file.Files
-import java.nio.file.StandardCopyOption
 import java.util.UUID
 
 enum class InstallRunResult {
@@ -27,7 +26,7 @@ class InstallHistoryStore(context: Context) {
     fun load(): List<InstallHistoryEntry> = directory
         .listFiles { file -> file.extension == "json" }
         .orEmpty()
-        .map(::decode)
+        .mapNotNull(::decodeOrQuarantine)
         .sortedByDescending(InstallHistoryEntry::startedAtMillis)
 
     fun closeInterruptedRuns(): List<InstallHistoryEntry> = load().map { entry ->
@@ -51,14 +50,17 @@ class InstallHistoryStore(context: Context) {
 
     fun save(entry: InstallHistoryEntry) {
         val target = File(directory, "${entry.id}.json")
-        val temporary = File(directory, "${entry.id}.tmp")
-        temporary.writeText(encode(entry).toString(), Charsets.UTF_8)
-        Files.move(
-            temporary.toPath(),
-            target.toPath(),
-            StandardCopyOption.REPLACE_EXISTING,
-            StandardCopyOption.ATOMIC_MOVE,
-        )
+        val atomicFile = AtomicFile(target)
+        val output = atomicFile.startWrite()
+        try {
+            output.write(encode(entry).toString().toByteArray(Charsets.UTF_8))
+            output.flush()
+            output.fd.sync()
+            atomicFile.finishWrite(output)
+        } catch (error: Throwable) {
+            atomicFile.failWrite(output)
+            throw error
+        }
     }
 
     private fun encode(entry: InstallHistoryEntry) = JSONObject()
@@ -68,8 +70,17 @@ class InstallHistoryStore(context: Context) {
         .put("result", entry.result.name)
         .put("log", entry.log)
 
-    private fun decode(file: File): InstallHistoryEntry {
-        val value = JSONObject(file.readText(Charsets.UTF_8))
+    private fun decodeOrQuarantine(file: File): InstallHistoryEntry? = try {
+        decode(AtomicFile(file).openRead().use { it.readBytes() })
+    } catch (_: Throwable) {
+        val quarantined = File(directory, "${file.name}.corrupt")
+        quarantined.delete()
+        file.renameTo(quarantined)
+        null
+    }
+
+    private fun decode(bytes: ByteArray): InstallHistoryEntry {
+        val value = JSONObject(bytes.toString(Charsets.UTF_8))
         return InstallHistoryEntry(
             id = value.getString("id"),
             startedAtMillis = value.getLong("startedAtMillis"),

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -2,7 +2,6 @@ package dev.busung.s25uroot
 
 import android.app.Application
 import android.os.SystemClock
-import android.provider.Settings
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +40,12 @@ data class InstallUiState(
 
 }
 
+data class TargetCatalogUiState(
+    val loading: Boolean = false,
+    val profiles: List<TargetProfile> = emptyList(),
+    val error: String? = null,
+)
+
 private data class CommandResult(val code: Int, val output: String)
 
 class InstallViewModel(application: Application) : AndroidViewModel(application) {
@@ -49,11 +54,13 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     private val historyStore = InstallHistoryStore(application)
     private val mutableState = MutableStateFlow(InstallUiState())
     private val mutableHistory = MutableStateFlow(historyStore.closeInterruptedRuns())
+    private val mutableTargetCatalog = MutableStateFlow(TargetCatalogUiState())
     private var discoveryJob: Job? = null
     private var installJob: Job? = null
     private var activeHistoryEntry: InstallHistoryEntry? = null
     val state: StateFlow<InstallUiState> = mutableState.asStateFlow()
     val history: StateFlow<List<InstallHistoryEntry>> = mutableHistory.asStateFlow()
+    val targetCatalog: StateFlow<TargetCatalogUiState> = mutableTargetCatalog.asStateFlow()
 
     init {
         refresh()
@@ -93,7 +100,23 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    fun install() {
+    fun loadTargetCatalog() {
+        if (mutableTargetCatalog.value.loading) return
+        viewModelScope.launch(Dispatchers.IO) {
+            mutableTargetCatalog.value = TargetCatalogUiState(loading = true)
+            mutableTargetCatalog.value = try {
+                TargetCatalogUiState(
+                    profiles = repository.loadTargets().sortedWith(
+                        compareBy(TargetProfile::manufacturer, TargetProfile::model, TargetProfile::buildDisplay),
+                    ),
+                )
+            } catch (error: Throwable) {
+                TargetCatalogUiState(error = error.message ?: error.javaClass.simpleName)
+            }
+        }
+    }
+
+    fun install(profileId: String? = null) {
         if (installJob?.isActive == true || mutableState.value.phase == InstallPhase.Installed) return
         discoveryJob?.cancel()
         installJob = viewModelScope.launch(Dispatchers.IO) {
@@ -104,7 +127,11 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             startHistory()
             try {
                 setPhase(InstallPhase.Checking, app.getString(R.string.status_checking_github))
-                val profile = repository.resolveTarget(DeviceSnapshot.current())
+                val profile = if (profileId == null) {
+                    repository.resolveTarget(DeviceSnapshot.current())
+                } else {
+                    repository.resolveTarget(profileId)
+                }
                 appendLog(app.getString(R.string.log_profile, profile.profileId))
 
                 setPhase(InstallPhase.Downloading, app.getString(R.string.status_downloading_payload))
@@ -221,6 +248,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     }
 
     private fun detectInstalled(): Boolean {
+        if (NativeProbe.isKernelSuActive()) return true
         val bootToken = currentBootToken() ?: return false
         val receipt = app.getSharedPreferences(INSTALL_RECEIPT, Application.MODE_PRIVATE)
         return receipt.getString(RECEIPT_BOOT_TOKEN, null) == bootToken &&
@@ -237,11 +265,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         require(stored) { app.getString(R.string.error_receipt) }
     }
 
-    private fun currentBootToken(): String? = Settings.Global.getInt(
-        app.contentResolver,
-        Settings.Global.BOOT_COUNT,
-        -1,
-    ).takeIf { it >= 0 }?.toString()
+    private fun currentBootToken(): String? = runCatching {
+        File("/proc/sys/kernel/random/boot_id")
+            .readText(Charsets.US_ASCII)
+            .trim()
+            .takeIf(String::isNotBlank)
+    }.getOrNull()
 
     private fun cachedP0Offset(bootToken: String?): String? {
         if (bootToken == null) return null
@@ -329,10 +358,10 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val EXPLOIT_STALL_MILLIS = 90_000L
         private const val EXPLOIT_TOTAL_MILLIS = 900_000L
         private const val INSTALL_RECEIPT = "install_receipt"
-        private const val RECEIPT_BOOT_TOKEN = "boot_count"
+        private const val RECEIPT_BOOT_TOKEN = "kernel_boot_id"
         private const val RECEIPT_VERIFIED = "verified"
         private const val P0_CACHE = "p0_cache"
-        private const val P0_CACHE_BOOT_TOKEN = "boot_count"
+        private const val P0_CACHE_BOOT_TOKEN = "kernel_boot_id"
         private const val P0_CACHE_OFFSET = "offset"
         private const val P0_OFFSET_ENV = "SLIDE_P0_OFFSET"
         private const val P0_OFFSET_MAX = 0x1f0000L

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -37,7 +37,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -61,18 +65,25 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.ToggleButton
@@ -115,24 +126,28 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.util.Date
+import java.util.UUID
 
 class MainActivity : ComponentActivity() {
     private val installViewModel by viewModels<InstallViewModel>()
     private var resumedOnce = false
     private var accentColor by mutableStateOf(AccentColor.Dynamic)
     private var themeMode by mutableStateOf(AppThemeMode.System)
+    private var advancedMode by mutableStateOf(false)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         accentColor = AppPreferences.accentColor(this)
         themeMode = AppPreferences.themeMode(this)
+        advancedMode = AppPreferences.advancedMode(this)
         setContent {
             RootMyGalaxyTheme(accentColor = accentColor, themeMode = themeMode) {
                 RootApp(
                     installViewModel = installViewModel,
                     accentColor = accentColor,
                     themeMode = themeMode,
+                    advancedMode = advancedMode,
                     onAccentColorChanged = { color ->
                         AppPreferences.setAccentColor(this, color)
                         accentColor = color
@@ -141,11 +156,17 @@ class MainActivity : ComponentActivity() {
                         AppPreferences.setThemeMode(this, mode)
                         themeMode = mode
                     },
-                    openInstaller = {
-                        startActivity(
-                            Intent(this, InstallActivity::class.java)
-                                .putExtra(InstallActivity.EXTRA_START_INSTALL, true),
-                        )
+                    onAdvancedModeChanged = { enabled ->
+                        AppPreferences.setAdvancedMode(this, enabled)
+                        advancedMode = enabled
+                    },
+                    openInstaller = { profileId ->
+                        val installer = Intent(this, InstallActivity::class.java)
+                            .putExtra(InstallActivity.EXTRA_INSTALL_REQUEST_ID, UUID.randomUUID().toString())
+                        if (profileId != null) {
+                            installer.putExtra(InstallActivity.EXTRA_PROFILE_ID, profileId)
+                        }
+                        startActivity(installer)
                     },
                 )
             }
@@ -166,6 +187,11 @@ private enum class AppPage(@StringRes val label: Int, val icon: ImageVector) {
 
 private data class LanguageOption(@StringRes val label: Int, val tag: String)
 
+private enum class CompatibilityWarning {
+    Device,
+    Build,
+}
+
 private val languageOptions = listOf(
     LanguageOption(R.string.language_system, ""),
     LanguageOption(R.string.language_korean, "ko"),
@@ -179,15 +205,96 @@ private fun RootApp(
     installViewModel: InstallViewModel,
     accentColor: AccentColor,
     themeMode: AppThemeMode,
+    advancedMode: Boolean,
     onAccentColorChanged: (AccentColor) -> Unit,
     onThemeModeChanged: (AppThemeMode) -> Unit,
-    openInstaller: () -> Unit,
+    onAdvancedModeChanged: (Boolean) -> Unit,
+    openInstaller: (String?) -> Unit,
 ) {
     val installState by installViewModel.state.collectAsStateWithLifecycle()
     val history by installViewModel.history.collectAsStateWithLifecycle()
+    val targetCatalog by installViewModel.targetCatalog.collectAsStateWithLifecycle()
     var selectedPage by remember { mutableStateOf(AppPage.Overview) }
     var showInstallConfirmation by remember { mutableStateOf(false) }
+    var showTargetPicker by remember { mutableStateOf(false) }
+    var selectedProfile by remember { mutableStateOf<TargetProfile?>(null) }
+    var compatibilityWarning by remember { mutableStateOf<CompatibilityWarning?>(null) }
     val device = remember { DeviceSnapshot.current() }
+
+    if (showTargetPicker) {
+        TargetSelectionSheet(
+            device = device,
+            catalog = targetCatalog,
+            onDismiss = { showTargetPicker = false },
+            onRetry = installViewModel::loadTargetCatalog,
+            onNext = { profile ->
+                selectedProfile = profile
+                showTargetPicker = false
+                compatibilityWarning = when {
+                    !profile.matchesModel(device) -> CompatibilityWarning.Device
+                    !profile.matches(device) -> CompatibilityWarning.Build
+                    else -> null
+                }
+                if (compatibilityWarning == null) showInstallConfirmation = true
+            },
+        )
+    }
+
+    compatibilityWarning?.let { warning ->
+        val profile = selectedProfile ?: return@let
+        AlertDialog(
+            onDismissRequest = {
+                compatibilityWarning = null
+                showTargetPicker = true
+            },
+            icon = { Icon(Icons.Rounded.Warning, contentDescription = null) },
+            title = {
+                DialogDimAmount(0.24f)
+                Text(
+                    stringResource(
+                        if (warning == CompatibilityWarning.Device) {
+                            R.string.device_mismatch_title
+                        } else {
+                            R.string.build_mismatch_title
+                        },
+                    ),
+                )
+            },
+            text = {
+                Text(
+                    if (warning == CompatibilityWarning.Device) {
+                        stringResource(R.string.device_mismatch_body, device.model, profile.model)
+                    } else {
+                        stringResource(R.string.build_mismatch_body, device.buildId, profile.buildDisplay)
+                    },
+                )
+            },
+            confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        if (warning == CompatibilityWarning.Device && !profile.matches(device)) {
+                            compatibilityWarning = CompatibilityWarning.Build
+                        } else {
+                            compatibilityWarning = null
+                            showInstallConfirmation = true
+                        }
+                    },
+                ) {
+                    Text(stringResource(R.string.action_continue))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        compatibilityWarning = null
+                        showTargetPicker = true
+                    },
+                ) {
+                    Text(stringResource(R.string.action_back))
+                }
+            },
+        )
+    }
 
     if (showInstallConfirmation) {
         AlertDialog(
@@ -201,7 +308,8 @@ private fun RootApp(
             confirmButton = {
                 FilledTonalButton(onClick = {
                     showInstallConfirmation = false
-                    openInstaller()
+                    openInstaller(selectedProfile?.profileId)
+                    selectedProfile = null
                 }) {
                     Text(stringResource(R.string.action_confirm))
                 }
@@ -239,15 +347,25 @@ private fun RootApp(
                     padding = padding,
                     device = device,
                     installState = installState,
-                    onInstall = { showInstallConfirmation = true },
+                    onInstall = {
+                        selectedProfile = null
+                        if (advancedMode) {
+                            showTargetPicker = true
+                            installViewModel.loadTargetCatalog()
+                        } else {
+                            showInstallConfirmation = true
+                        }
+                    },
                 )
                 AppPage.History -> HistoryPage(padding, history)
                 AppPage.Settings -> SettingsPage(
                     padding = padding,
                     accentColor = accentColor,
                     themeMode = themeMode,
+                    advancedMode = advancedMode,
                     onAccentColorChanged = onAccentColorChanged,
                     onThemeModeChanged = onThemeModeChanged,
+                    onAdvancedModeChanged = onAdvancedModeChanged,
                 )
             }
         }
@@ -656,8 +774,10 @@ private fun SettingsPage(
     padding: PaddingValues,
     accentColor: AccentColor,
     themeMode: AppThemeMode,
+    advancedMode: Boolean,
     onAccentColorChanged: (AccentColor) -> Unit,
     onThemeModeChanged: (AppThemeMode) -> Unit,
+    onAdvancedModeChanged: (Boolean) -> Unit,
 ) {
     val context = LocalContext.current
     var showLanguageDialog by remember { mutableStateOf(false) }
@@ -741,6 +861,171 @@ private fun SettingsPage(
                 onClick = { showColorDialog = true },
             )
         }
+        item { SectionLabel(stringResource(R.string.advanced)) }
+        item {
+            SettingsSwitchCard(
+                icon = Icons.Rounded.Memory,
+                title = stringResource(R.string.advanced_mode),
+                description = stringResource(R.string.advanced_mode_description),
+                checked = advancedMode,
+                onCheckedChange = onAdvancedModeChanged,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TargetSelectionSheet(
+    device: DeviceSnapshot,
+    catalog: TargetCatalogUiState,
+    onDismiss: () -> Unit,
+    onRetry: () -> Unit,
+    onNext: (TargetProfile) -> Unit,
+) {
+    var showOnlyMyModel by remember { mutableStateOf(true) }
+    var selectedProfileId by remember { mutableStateOf<String?>(null) }
+    val visibleProfiles = remember(catalog.profiles, showOnlyMyModel, device) {
+        if (showOnlyMyModel) {
+            catalog.profiles.filter { it.matchesModel(device) }
+        } else {
+            catalog.profiles
+        }
+    }
+    val selectedProfile = catalog.profiles.firstOrNull { it.profileId == selectedProfileId }
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    stringResource(R.string.select_device_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                )
+                Text(
+                    stringResource(R.string.select_device_description),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .toggleable(
+                        value = showOnlyMyModel,
+                        role = Role.Checkbox,
+                        onValueChange = { enabled ->
+                            showOnlyMyModel = enabled
+                            if (enabled && selectedProfile?.matchesModel(device) == false) {
+                                selectedProfileId = null
+                            }
+                        },
+                    )
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Checkbox(checked = showOnlyMyModel, onCheckedChange = null)
+                Text(stringResource(R.string.show_my_model_only), style = MaterialTheme.typography.titleMedium)
+            }
+
+            when {
+                catalog.loading -> Box(
+                    modifier = Modifier.fillMaxWidth().height(220.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    LoadingIndicator()
+                }
+                catalog.error != null -> Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 32.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(catalog.error, color = MaterialTheme.colorScheme.error)
+                    FilledTonalButton(onClick = onRetry) {
+                        Text(stringResource(R.string.action_retry))
+                    }
+                }
+                visibleProfiles.isEmpty() -> Text(
+                    stringResource(R.string.no_matching_devices),
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                else -> LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 480.dp)
+                        .selectableGroup(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    items(visibleProfiles, key = TargetProfile::profileId) { profile ->
+                        val selected = selectedProfileId == profile.profileId
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = MaterialTheme.shapes.large,
+                            color = if (selected) {
+                                MaterialTheme.colorScheme.primaryContainer
+                            } else {
+                                MaterialTheme.colorScheme.surfaceContainerHighest
+                            },
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .selectable(
+                                        selected = selected,
+                                        role = Role.RadioButton,
+                                        onClick = { selectedProfileId = profile.profileId },
+                                    )
+                                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            ) {
+                                RadioButton(selected = selected, onClick = null)
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        "${profile.manufacturer} ${profile.model}",
+                                        style = MaterialTheme.typography.titleMedium,
+                                    )
+                                    Text(
+                                        profile.buildDisplay,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                    Text(
+                                        profile.profileId,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            HorizontalDivider()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TextButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+                Button(
+                    onClick = { selectedProfile?.let(onNext) },
+                    enabled = selectedProfile != null,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text(stringResource(R.string.action_next))
+                }
+            }
+        }
     }
 }
 
@@ -795,6 +1080,43 @@ private fun SettingsCard(
                 color = MaterialTheme.colorScheme.primary,
                 maxLines = 1,
             )
+        }
+    }
+}
+
+@Composable
+private fun SettingsSwitchCard(
+    icon: ImageVector,
+    title: String,
+    description: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    Card(
+        onClick = { onCheckedChange(!checked) },
+        modifier = Modifier.fillMaxWidth(),
+        shape = expressiveClickableCardShape(interactionSource),
+        interactionSource = interactionSource,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(28.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(title, style = MaterialTheme.typography.titleMedium)
+                Text(
+                    description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            Switch(checked = checked, onCheckedChange = null)
         }
     }
 }

--- a/app/src/main/java/dev/busung/s25uroot/NativeProbe.kt
+++ b/app/src/main/java/dev/busung/s25uroot/NativeProbe.kt
@@ -6,5 +6,6 @@ object NativeProbe {
     }
 
     external fun run(): String
-}
 
+    external fun isKernelSuActive(): Boolean
+}

--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -20,7 +20,7 @@ data class VerifiedPayloads(
 )
 
 class PayloadRepository(private val context: Context) {
-    fun resolveTarget(snapshot: DeviceSnapshot): TargetProfile {
+    fun loadTargets(): List<TargetProfile> {
         val commit = resolveMainCommit()
         val manifestBytes = downloadBytes(rawUrl(commit, "support/targets-v2.json"), MAX_MANIFEST_BYTES)
         val signatureBytes = Base64.decode(
@@ -30,18 +30,23 @@ class PayloadRepository(private val context: Context) {
             Base64.DEFAULT,
         )
         verifyManifest(manifestBytes, signatureBytes)
-        val profile = SupportManifest.parse(manifestBytes).targets
-            .firstOrNull { it.matches(snapshot) }
-            ?: error(context.getString(R.string.repo_no_profile))
-        return profile.copy(
+        return SupportManifest.parse(manifestBytes).targets.map { profile -> profile.copy(
             exploit = profile.exploit.copy(url = pinArtifactUrl(profile.exploit.url, commit)),
             kernelSu = profile.kernelSu.copy(
                 artifact = profile.kernelSu.artifact.copy(
                     url = pinArtifactUrl(profile.kernelSu.artifact.url, commit),
                 ),
             ),
-        )
+        ) }
     }
+
+    fun resolveTarget(snapshot: DeviceSnapshot): TargetProfile = loadTargets()
+        .firstOrNull { it.matches(snapshot) }
+        ?: error(context.getString(R.string.repo_no_profile))
+
+    fun resolveTarget(profileId: String): TargetProfile = loadTargets()
+        .firstOrNull { it.profileId == profileId }
+        ?: error(context.getString(R.string.repo_profile_missing, profileId))
 
     fun download(profile: TargetProfile, onProgress: (String) -> Unit): VerifiedPayloads {
         val directory = File(context.filesDir, "payloads/${profile.profileId}").apply { mkdirs() }

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -26,10 +26,13 @@ data class TargetProfile(
     val exploit: RemoteArtifact,
     val kernelSu: KernelSuArtifact,
 ) {
-    fun matches(snapshot: DeviceSnapshot): Boolean =
+    fun matchesModel(snapshot: DeviceSnapshot): Boolean =
         manufacturer.equals(snapshot.manufacturer, ignoreCase = true) &&
             model == snapshot.model &&
-            device == snapshot.device &&
+            device == snapshot.device
+
+    fun matches(snapshot: DeviceSnapshot): Boolean =
+        matchesModel(snapshot) &&
             buildDisplay == snapshot.buildId &&
             buildFingerprint == snapshot.fingerprint &&
             sdk == snapshot.sdk &&

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,4 +19,10 @@
     <string name="open_github">GitHubを開く</string>
     <string name="github_card_title">Root My Galaxyについて</string>
     <string name="github_card_description">ソースコードと使用方法を確認します。</string>
+    <string name="action_continue">無視して続行</string><string name="action_next">次へ</string>
+    <string name="advanced">詳細設定</string><string name="advanced_mode">詳細モード</string><string name="advanced_mode_description">インストールするデバイスとファームウェアを手動で選択</string>
+    <string name="repo_profile_missing">対応プロファイル%1$sは利用できなくなりました</string>
+    <string name="select_device_title">対応プロファイルを選択</string><string name="select_device_description">今回のインストールに使用するデバイスとファームウェアを選択します。</string><string name="show_my_model_only">自分のモデルのみ表示</string><string name="no_matching_devices">このモデルに一致するプロファイルはありません。</string>
+    <string name="device_mismatch_title">デバイスが一致しません</string><string name="device_mismatch_body">現在の端末は%1$sですが、選択したプロファイルは%2$s用です。実行すると端末が停止または破損する可能性があります。</string>
+    <string name="build_mismatch_title">ファームウェアが一致しません</string><string name="build_mismatch_body">現在のビルドは%1$sですが、選択したプロファイルは%2$s用です。オフセットに互換性がない可能性があります。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -20,4 +20,10 @@
     <string name="open_github">GitHub 열기</string>
     <string name="github_card_title">Root My Galaxy 알아보기</string>
     <string name="github_card_description">소스코드 및 사용 방법을 확인합니다.</string>
+    <string name="action_continue">무시하고 계속</string><string name="action_next">다음</string>
+    <string name="advanced">고급</string><string name="advanced_mode">고급 모드</string><string name="advanced_mode_description">설치할 기기와 펌웨어 프로필을 직접 선택합니다</string>
+    <string name="repo_profile_missing">지원 프로필 %1$s을(를) 더 이상 사용할 수 없습니다</string>
+    <string name="select_device_title">지원 프로필 선택</string><string name="select_device_description">이번 설치에 사용할 기기와 펌웨어 프로필을 선택합니다.</string><string name="show_my_model_only">내 모델만 보기</string><string name="no_matching_devices">이 모델에 맞는 프로필이 없습니다.</string>
+    <string name="device_mismatch_title">기기가 일치하지 않습니다</string><string name="device_mismatch_body">현재 기기는 %1$s이지만 선택한 프로필은 %2$s용입니다. 실행하면 기기가 멈추거나 손상될 수 있습니다.</string>
+    <string name="build_mismatch_title">빌드가 일치하지 않습니다</string><string name="build_mismatch_body">현재 빌드는 %1$s이지만 선택한 프로필은 %2$s용입니다. 오프셋이 호환되지 않을 수 있습니다.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -19,4 +19,10 @@
     <string name="open_github">打开 GitHub</string>
     <string name="github_card_title">了解 Root My Galaxy</string>
     <string name="github_card_description">查看源代码和使用方法。</string>
+    <string name="action_continue">忽略并继续</string><string name="action_next">下一步</string>
+    <string name="advanced">高级</string><string name="advanced_mode">高级模式</string><string name="advanced_mode_description">安装时手动选择设备和固件配置</string>
+    <string name="repo_profile_missing">支持配置 %1$s 已不可用</string>
+    <string name="select_device_title">选择支持配置</string><string name="select_device_description">选择本次安装要使用的设备和固件配置。</string><string name="show_my_model_only">仅显示我的型号</string><string name="no_matching_devices">没有与此型号匹配的配置。</string>
+    <string name="device_mismatch_title">设备不匹配</string><string name="device_mismatch_body">当前设备是 %1$s，但所选配置适用于 %2$s。运行可能导致设备停止响应或损坏。</string>
+    <string name="build_mismatch_title">固件不匹配</string><string name="build_mismatch_body">当前版本是 %1$s，但所选配置适用于 %2$s。偏移量可能不兼容。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,18 @@
     <string name="open_github">Open GitHub</string>
     <string name="github_card_title">Explore Root My Galaxy</string>
     <string name="github_card_description">View the source code and usage instructions.</string>
+    <string name="action_continue">Continue anyway</string>
+    <string name="action_next">Next</string>
+    <string name="advanced">Advanced</string>
+    <string name="advanced_mode">Advanced mode</string>
+    <string name="advanced_mode_description">Manually choose a device and firmware profile during installation</string>
+    <string name="repo_profile_missing">Support profile %1$s is no longer available</string>
+    <string name="select_device_title">Choose a support profile</string>
+    <string name="select_device_description">Select the device and firmware profile to use for this installation.</string>
+    <string name="show_my_model_only">Show only my model</string>
+    <string name="no_matching_devices">No profiles match this model.</string>
+    <string name="device_mismatch_title">Device mismatch</string>
+    <string name="device_mismatch_body">This phone is %1$s, but the selected profile is for %2$s. Running it may crash or damage the device.</string>
+    <string name="build_mismatch_title">Firmware mismatch</string>
+    <string name="build_mismatch_body">This phone uses build %1$s, but the selected profile targets %2$s. Offsets may be incompatible.</string>
 </resources>


### PR DESCRIPTION
## Summary
- keep KernelSU installation state across soft reboot by binding verification to the live kernel boot ID and probing the loaded module
- store install history with AtomicFile recovery and consume install requests exactly once after process or device restart
- add an advanced Material 3 Expressive profile picker with model filtering and sequential device/build mismatch warnings
- localize the new flow in English, Korean, Japanese, and Simplified Chinese

## Verification
- `:app:assembleDebug` (Android Studio JBR 21, Android SDK from LOCALAPPDATA)
- no device exploit or KernelSU runtime test was run; device validation is intentionally left to the maintainer

## Scope
- app repository only; no exploit, offset, or payload repository changes