### PR TITLE
Release v0.2.1 with kernel matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,23 @@ The signed device feed and native payloads are maintained in
 The standalone CVE proof of concept remains in
 [CVE-2026-43499-S25U](https://github.com/BuSung-dev/CVE-2026-43499-S25U).
 
-## Current target
+## Current profiles
 
 ```text
-Samsung Galaxy S25 Ultra SM-S938N
-pa3q / S938NKSUACZF1 / Android 16 / arm64-v8a / 4K
+Galaxy S25 Ultra / 6.6.98-android15-8-pd6ff1cd-abogkiS938NKSUACZF1-4k
+Galaxy S24 FE / 6.1.157-android14-11
 ```
 
-The app requires an exact signed match for the manufacturer, model, device,
-full build display ID, full fingerprint, SDK, ABI, and page size.
+The app automatically selects an exact signed match for the kernel release,
+full build display ID, SDK, ABI, and page size. Advanced mode can select a
+profile manually and presents separate kernel-release and build warnings.
 
 ## Download model
 
 1. Resolve the current `main` commit of the payload repository.
 2. Download the support manifest and Ed25519 signature from that exact commit.
 3. Verify the signature with the public key pinned in the APK.
-4. Match the complete device profile.
+4. Match the kernel release and exact automatic-selection fields.
 5. Download the exploit and KernelSU artifacts from the same immutable commit.
 
 Per-artifact SHA-256 fields are intentionally not used. The signed manifest

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.busung.s25uroot"
         minSdk = 33
         targetSdk = 36
-        versionCode = 5
-        versionName = "0.2.0"
+        versionCode = 6
+        versionName = "0.2.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {

--- a/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
+++ b/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
@@ -8,6 +8,7 @@ data class DeviceSnapshot(
     val manufacturer: String,
     val model: String,
     val device: String,
+    val kernelRelease: String,
     val buildId: String,
     val fingerprint: String,
     val androidRelease: String,
@@ -16,13 +17,14 @@ data class DeviceSnapshot(
     val pageSize: Long,
 ) {
     val targetLabel: String
-        get() = "$model / $buildId"
+        get() = "$kernelRelease / $buildId"
 
     companion object {
         fun current() = DeviceSnapshot(
             manufacturer = Build.MANUFACTURER,
             model = Build.MODEL,
             device = Build.DEVICE,
+            kernelRelease = Os.uname().release,
             buildId = Build.DISPLAY,
             fingerprint = Build.FINGERPRINT,
             androidRelease = Build.VERSION.RELEASE,

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -107,7 +107,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             mutableTargetCatalog.value = try {
                 TargetCatalogUiState(
                     profiles = repository.loadTargets().sortedWith(
-                        compareBy(TargetProfile::manufacturer, TargetProfile::model, TargetProfile::buildDisplay),
+                        compareBy(TargetProfile::kernelRelease, TargetProfile::model, TargetProfile::buildDisplay),
                     ),
                 )
             } catch (error: Throwable) {

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -188,7 +188,7 @@ private enum class AppPage(@StringRes val label: Int, val icon: ImageVector) {
 private data class LanguageOption(@StringRes val label: Int, val tag: String)
 
 private enum class CompatibilityWarning {
-    Device,
+    Kernel,
     Build,
 }
 
@@ -234,8 +234,8 @@ private fun RootApp(
                 selectedProfile = profile
                 showTargetPicker = false
                 compatibilityWarning = when {
-                    !profile.matchesModel(device) -> CompatibilityWarning.Device
-                    !profile.matches(device) -> CompatibilityWarning.Build
+                    !profile.matchesKernel(device) -> CompatibilityWarning.Kernel
+                    profile.buildDisplay != device.buildId -> CompatibilityWarning.Build
                     else -> null
                 }
                 if (compatibilityWarning == null) showInstallConfirmation = true
@@ -255,8 +255,8 @@ private fun RootApp(
                 DialogDimAmount(0.24f)
                 Text(
                     stringResource(
-                        if (warning == CompatibilityWarning.Device) {
-                            R.string.device_mismatch_title
+                        if (warning == CompatibilityWarning.Kernel) {
+                            R.string.kernel_mismatch_title
                         } else {
                             R.string.build_mismatch_title
                         },
@@ -265,8 +265,12 @@ private fun RootApp(
             },
             text = {
                 Text(
-                    if (warning == CompatibilityWarning.Device) {
-                        stringResource(R.string.device_mismatch_body, device.model, profile.model)
+                    if (warning == CompatibilityWarning.Kernel) {
+                        stringResource(
+                            R.string.kernel_mismatch_body,
+                            device.kernelRelease,
+                            profile.kernelRelease,
+                        )
                     } else {
                         stringResource(R.string.build_mismatch_body, device.buildId, profile.buildDisplay)
                     },
@@ -275,7 +279,10 @@ private fun RootApp(
             confirmButton = {
                 FilledTonalButton(
                     onClick = {
-                        if (warning == CompatibilityWarning.Device && !profile.matches(device)) {
+                        if (
+                            warning == CompatibilityWarning.Kernel &&
+                            profile.buildDisplay != device.buildId
+                        ) {
                             compatibilityWarning = CompatibilityWarning.Build
                         } else {
                             compatibilityWarning = null
@@ -896,11 +903,11 @@ private fun TargetSelectionSheet(
     onRetry: () -> Unit,
     onNext: (TargetProfile) -> Unit,
 ) {
-    var showOnlyMyModel by remember { mutableStateOf(true) }
+    var showOnlyMyKernel by remember { mutableStateOf(true) }
     var selectedProfileId by remember { mutableStateOf<String?>(null) }
-    val visibleProfiles = remember(catalog.profiles, showOnlyMyModel, device) {
-        if (showOnlyMyModel) {
-            catalog.profiles.filter { it.matchesModel(device) }
+    val visibleProfiles = remember(catalog.profiles, showOnlyMyKernel, device) {
+        if (showOnlyMyKernel) {
+            catalog.profiles.filter { it.matchesKernel(device) }
         } else {
             catalog.profiles
         }
@@ -930,11 +937,11 @@ private fun TargetSelectionSheet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .toggleable(
-                        value = showOnlyMyModel,
+                        value = showOnlyMyKernel,
                         role = Role.Checkbox,
                         onValueChange = { enabled ->
-                            showOnlyMyModel = enabled
-                            if (enabled && selectedProfile?.matchesModel(device) == false) {
+                            showOnlyMyKernel = enabled
+                            if (enabled && selectedProfile?.matchesKernel(device) == false) {
                                 selectedProfileId = null
                             }
                         },
@@ -943,8 +950,8 @@ private fun TargetSelectionSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Checkbox(checked = showOnlyMyModel, onCheckedChange = null)
-                Text(stringResource(R.string.show_my_model_only), style = MaterialTheme.typography.titleMedium)
+                Checkbox(checked = showOnlyMyKernel, onCheckedChange = null)
+                Text(stringResource(R.string.show_my_kernel_only), style = MaterialTheme.typography.titleMedium)
             }
 
             when {
@@ -965,7 +972,7 @@ private fun TargetSelectionSheet(
                     }
                 }
                 visibleProfiles.isEmpty() -> Text(
-                    stringResource(R.string.no_matching_devices),
+                    stringResource(R.string.no_matching_kernels),
                     modifier = Modifier.fillMaxWidth().padding(vertical = 48.dp),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1002,11 +1009,11 @@ private fun TargetSelectionSheet(
                                 RadioButton(selected = selected, onClick = null)
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(
-                                        "${profile.manufacturer} ${profile.model}",
+                                        profile.kernelRelease,
                                         style = MaterialTheme.typography.titleMedium,
                                     )
                                     Text(
-                                        profile.buildDisplay,
+                                        "${profile.manufacturer} ${profile.model} · ${profile.buildDisplay}",
                                         style = MaterialTheme.typography.bodyMedium,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     )

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -18,6 +18,7 @@ data class TargetProfile(
     val manufacturer: String,
     val model: String,
     val device: String,
+    val kernelRelease: String,
     val buildDisplay: String,
     val buildFingerprint: String,
     val sdk: Int,
@@ -26,15 +27,12 @@ data class TargetProfile(
     val exploit: RemoteArtifact,
     val kernelSu: KernelSuArtifact,
 ) {
-    fun matchesModel(snapshot: DeviceSnapshot): Boolean =
-        manufacturer.equals(snapshot.manufacturer, ignoreCase = true) &&
-            model == snapshot.model &&
-            device == snapshot.device
+    fun matchesKernel(snapshot: DeviceSnapshot): Boolean =
+        kernelRelease == snapshot.kernelRelease
 
     fun matches(snapshot: DeviceSnapshot): Boolean =
-        matchesModel(snapshot) &&
+        matchesKernel(snapshot) &&
             buildDisplay == snapshot.buildId &&
-            buildFingerprint == snapshot.fingerprint &&
             sdk == snapshot.sdk &&
             abi == snapshot.abi &&
             pageSize == snapshot.pageSize
@@ -61,6 +59,7 @@ data class SupportManifest(
                             manufacturer = target.getString("manufacturer"),
                             model = target.getString("model"),
                             device = target.getString("device"),
+                            kernelRelease = target.getString("kernelRelease"),
                             buildDisplay = target.getString("buildDisplay"),
                             buildFingerprint = target.getString("buildFingerprint"),
                             sdk = target.getInt("sdk"),

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,9 +20,9 @@
     <string name="github_card_title">Root My Galaxyについて</string>
     <string name="github_card_description">ソースコードと使用方法を確認します。</string>
     <string name="action_continue">無視して続行</string><string name="action_next">次へ</string>
-    <string name="advanced">詳細設定</string><string name="advanced_mode">詳細モード</string><string name="advanced_mode_description">インストールするデバイスとファームウェアを手動で選択</string>
+    <string name="advanced">詳細設定</string><string name="advanced_mode">詳細モード</string><string name="advanced_mode_description">インストールするカーネルとファームウェアプロファイルを手動で選択</string>
     <string name="repo_profile_missing">対応プロファイル%1$sは利用できなくなりました</string>
-    <string name="select_device_title">対応プロファイルを選択</string><string name="select_device_description">今回のインストールに使用するデバイスとファームウェアを選択します。</string><string name="show_my_model_only">自分のモデルのみ表示</string><string name="no_matching_devices">このモデルに一致するプロファイルはありません。</string>
-    <string name="device_mismatch_title">デバイスが一致しません</string><string name="device_mismatch_body">現在の端末は%1$sですが、選択したプロファイルは%2$s用です。実行すると端末が停止または破損する可能性があります。</string>
+    <string name="select_device_title">対応プロファイルを選択</string><string name="select_device_description">今回のインストールに使用するカーネルとファームウェアプロファイルを選択します。</string><string name="show_my_kernel_only">自分のカーネルのみ表示</string><string name="no_matching_kernels">このカーネルに一致するプロファイルはありません。</string>
+    <string name="kernel_mismatch_title">カーネルが一致しません</string><string name="kernel_mismatch_body">現在のカーネルは%1$sですが、選択したプロファイルのカーネルは%2$sです。実行すると端末が停止または破損する可能性があります。</string>
     <string name="build_mismatch_title">ファームウェアが一致しません</string><string name="build_mismatch_body">現在のビルドは%1$sですが、選択したプロファイルは%2$s用です。オフセットに互換性がない可能性があります。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -21,9 +21,9 @@
     <string name="github_card_title">Root My Galaxy 알아보기</string>
     <string name="github_card_description">소스코드 및 사용 방법을 확인합니다.</string>
     <string name="action_continue">무시하고 계속</string><string name="action_next">다음</string>
-    <string name="advanced">고급</string><string name="advanced_mode">고급 모드</string><string name="advanced_mode_description">설치할 기기와 펌웨어 프로필을 직접 선택합니다</string>
+    <string name="advanced">고급</string><string name="advanced_mode">고급 모드</string><string name="advanced_mode_description">설치할 커널과 펌웨어 프로필을 직접 선택합니다</string>
     <string name="repo_profile_missing">지원 프로필 %1$s을(를) 더 이상 사용할 수 없습니다</string>
-    <string name="select_device_title">지원 프로필 선택</string><string name="select_device_description">이번 설치에 사용할 기기와 펌웨어 프로필을 선택합니다.</string><string name="show_my_model_only">내 모델만 보기</string><string name="no_matching_devices">이 모델에 맞는 프로필이 없습니다.</string>
-    <string name="device_mismatch_title">기기가 일치하지 않습니다</string><string name="device_mismatch_body">현재 기기는 %1$s이지만 선택한 프로필은 %2$s용입니다. 실행하면 기기가 멈추거나 손상될 수 있습니다.</string>
+    <string name="select_device_title">지원 프로필 선택</string><string name="select_device_description">이번 설치에 사용할 커널과 펌웨어 프로필을 선택합니다.</string><string name="show_my_kernel_only">내 커널만 보기</string><string name="no_matching_kernels">이 커널에 맞는 프로필이 없습니다.</string>
+    <string name="kernel_mismatch_title">커널이 일치하지 않습니다</string><string name="kernel_mismatch_body">현재 커널은 %1$s이지만 선택한 프로필의 커널은 %2$s입니다. 실행하면 기기가 멈추거나 손상될 수 있습니다.</string>
     <string name="build_mismatch_title">빌드가 일치하지 않습니다</string><string name="build_mismatch_body">현재 빌드는 %1$s이지만 선택한 프로필은 %2$s용입니다. 오프셋이 호환되지 않을 수 있습니다.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,9 +20,9 @@
     <string name="github_card_title">了解 Root My Galaxy</string>
     <string name="github_card_description">查看源代码和使用方法。</string>
     <string name="action_continue">忽略并继续</string><string name="action_next">下一步</string>
-    <string name="advanced">高级</string><string name="advanced_mode">高级模式</string><string name="advanced_mode_description">安装时手动选择设备和固件配置</string>
+    <string name="advanced">高级</string><string name="advanced_mode">高级模式</string><string name="advanced_mode_description">安装时手动选择内核和固件配置</string>
     <string name="repo_profile_missing">支持配置 %1$s 已不可用</string>
-    <string name="select_device_title">选择支持配置</string><string name="select_device_description">选择本次安装要使用的设备和固件配置。</string><string name="show_my_model_only">仅显示我的型号</string><string name="no_matching_devices">没有与此型号匹配的配置。</string>
-    <string name="device_mismatch_title">设备不匹配</string><string name="device_mismatch_body">当前设备是 %1$s，但所选配置适用于 %2$s。运行可能导致设备停止响应或损坏。</string>
+    <string name="select_device_title">选择支持配置</string><string name="select_device_description">选择本次安装要使用的内核和固件配置。</string><string name="show_my_kernel_only">仅显示我的内核</string><string name="no_matching_kernels">没有与此内核匹配的配置。</string>
+    <string name="kernel_mismatch_title">内核不匹配</string><string name="kernel_mismatch_body">当前内核为 %1$s，但所选配置的内核为 %2$s。运行可能导致设备停止响应或损坏。</string>
     <string name="build_mismatch_title">固件不匹配</string><string name="build_mismatch_body">当前版本是 %1$s，但所选配置适用于 %2$s。偏移量可能不兼容。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,14 +115,14 @@
     <string name="action_next">Next</string>
     <string name="advanced">Advanced</string>
     <string name="advanced_mode">Advanced mode</string>
-    <string name="advanced_mode_description">Manually choose a device and firmware profile during installation</string>
+    <string name="advanced_mode_description">Manually choose a kernel and firmware profile during installation</string>
     <string name="repo_profile_missing">Support profile %1$s is no longer available</string>
     <string name="select_device_title">Choose a support profile</string>
-    <string name="select_device_description">Select the device and firmware profile to use for this installation.</string>
-    <string name="show_my_model_only">Show only my model</string>
-    <string name="no_matching_devices">No profiles match this model.</string>
-    <string name="device_mismatch_title">Device mismatch</string>
-    <string name="device_mismatch_body">This phone is %1$s, but the selected profile is for %2$s. Running it may crash or damage the device.</string>
+    <string name="select_device_description">Select the kernel and firmware profile to use for this installation.</string>
+    <string name="show_my_kernel_only">Show only my kernel</string>
+    <string name="no_matching_kernels">No profiles match this kernel.</string>
+    <string name="kernel_mismatch_title">Kernel mismatch</string>
+    <string name="kernel_mismatch_body">This phone uses kernel %1$s, but the selected profile targets %2$s. Running it may crash or damage the device.</string>
     <string name="build_mismatch_title">Firmware mismatch</string>
     <string name="build_mismatch_body">This phone uses build %1$s, but the selected profile targets %2$s. Offsets may be incompatible.</string>
 </resources>


### PR DESCRIPTION
## What changed

- replace model/device compatibility matching with the exact `uname -r` kernel release
- make advanced-mode filtering show profiles for the current kernel
- replace the device mismatch dialog with a kernel-release mismatch dialog
- keep the existing firmware build mismatch warning as the second confirmation
- display kernel releases in the advanced profile list
- bump the app to `0.2.1` (`versionCode 6`)

## Why

Regional Samsung variants can share a kernel and use the same exploit offsets despite different model and device identifiers. Model-based filtering hid those compatible profiles.

## Validation

- payload feed v2 was published first with required `kernelRelease` fields and a verified Ed25519 signature
- `:app:assembleDebug` completed successfully
- APK metadata reports `versionCode=6` and `versionName=0.2.1`
- all four localized resource sets compiled successfully
