### PR TITLE
Match exact kernel version strings

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
+++ b/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
@@ -3,12 +3,14 @@ package dev.busung.s25uroot
 import android.os.Build
 import android.system.Os
 import android.system.OsConstants
+import java.io.File
 
 data class DeviceSnapshot(
     val manufacturer: String,
     val model: String,
     val device: String,
     val kernelRelease: String,
+    val kernelVersion: String,
     val buildId: String,
     val fingerprint: String,
     val androidRelease: String,
@@ -25,6 +27,7 @@ data class DeviceSnapshot(
             model = Build.MODEL,
             device = Build.DEVICE,
             kernelRelease = Os.uname().release,
+            kernelVersion = File("/proc/version").readText(Charsets.US_ASCII).trim(),
             buildId = Build.DISPLAY,
             fingerprint = Build.FINGERPRINT,
             androidRelease = Build.VERSION.RELEASE,

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -107,7 +107,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             mutableTargetCatalog.value = try {
                 TargetCatalogUiState(
                     profiles = repository.loadTargets().sortedWith(
-                        compareBy(TargetProfile::kernelRelease, TargetProfile::model, TargetProfile::buildDisplay),
+                        compareBy(
+                            TargetProfile::kernelRelease,
+                            TargetProfile::kernelVersion,
+                            TargetProfile::model,
+                            TargetProfile::buildDisplay,
+                        ),
                     ),
                 )
             } catch (error: Throwable) {

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -268,8 +268,8 @@ private fun RootApp(
                     if (warning == CompatibilityWarning.Kernel) {
                         stringResource(
                             R.string.kernel_mismatch_body,
-                            device.kernelRelease,
-                            profile.kernelRelease,
+                            device.kernelVersion,
+                            profile.kernelVersion,
                         )
                     } else {
                         stringResource(R.string.build_mismatch_body, device.buildId, profile.buildDisplay)

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -19,6 +19,7 @@ data class TargetProfile(
     val model: String,
     val device: String,
     val kernelRelease: String,
+    val kernelVersion: String,
     val buildDisplay: String,
     val buildFingerprint: String,
     val sdk: Int,
@@ -28,7 +29,8 @@ data class TargetProfile(
     val kernelSu: KernelSuArtifact,
 ) {
     fun matchesKernel(snapshot: DeviceSnapshot): Boolean =
-        kernelRelease == snapshot.kernelRelease
+        kernelRelease == snapshot.kernelRelease &&
+            kernelVersion == snapshot.kernelVersion
 
     fun matches(snapshot: DeviceSnapshot): Boolean =
         matchesKernel(snapshot) &&
@@ -60,6 +62,7 @@ data class SupportManifest(
                             model = target.getString("model"),
                             device = target.getString("device"),
                             kernelRelease = target.getString("kernelRelease"),
+                            kernelVersion = target.getString("kernelVersion"),
                             buildDisplay = target.getString("buildDisplay"),
                             buildFingerprint = target.getString("buildFingerprint"),
                             sdk = target.getInt("sdk"),


### PR DESCRIPTION
## What changed

- read the complete running kernel identity from `/proc/version`
- require both `uname -r` and the full version banner when matching profiles
- use the full version banner in compatibility warnings
- sort otherwise identical releases by their full kernel build identity

## Why

Samsung kernels can expose the same `uname -r` while containing different Images and exploit offsets. Release-only matching therefore grouped incompatible S24 FE and S24 profiles together.

## Impact

Automatic selection and the advanced-mode "my kernel only" filter now distinguish exact vendor kernel builds. Profiles with the same short release but a different build banner produce the existing kernel mismatch warning and can only be selected through the explicit advanced-mode override.

## Validation

- built `:app:assembleDebug` successfully with JDK 21 and the local Android SDK
- verified every signed feed banner against its retained kernel Image
- ran `git diff --check`

No device installation or runtime exploit test was performed.
