### PR TITLE
Fix Ed25519 verification for v0.2.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "dev.busung.s25uroot"
         minSdk = 33
         targetSdk = 36
-        versionCode = 6
-        versionName = "0.2.1"
+        versionCode = 7
+        versionName = "0.2.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
@@ -71,8 +71,10 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
     implementation("com.materialkolor:material-kolor:4.1.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.84")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
+    testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test:core-ktx:1.7.0")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test:runner:1.7.0")

--- a/app/src/main/java/dev/busung/s25uroot/Ed25519Verifier.kt
+++ b/app/src/main/java/dev/busung/s25uroot/Ed25519Verifier.kt
@@ -1,0 +1,18 @@
+package dev.busung.s25uroot
+
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters
+import org.bouncycastle.crypto.signers.Ed25519Signer
+
+internal object Ed25519Verifier {
+    fun verify(publicKey: ByteArray, message: ByteArray, signature: ByteArray): Boolean {
+        if (publicKey.size != PUBLIC_KEY_SIZE || signature.size != SIGNATURE_SIZE) return false
+
+        val verifier = Ed25519Signer()
+        verifier.init(false, Ed25519PublicKeyParameters(publicKey, 0))
+        verifier.update(message, 0, message.size)
+        return verifier.verifySignature(signature)
+    }
+
+    private const val PUBLIC_KEY_SIZE = 32
+    private const val SIGNATURE_SIZE = 64
+}

--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -8,9 +8,6 @@ import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
 import java.net.URL
-import java.security.KeyFactory
-import java.security.Signature
-import java.security.spec.X509EncodedKeySpec
 import org.json.JSONObject
 
 data class VerifiedPayloads(
@@ -106,13 +103,10 @@ class PayloadRepository(private val context: Context) {
     }
 
     private fun verifyManifest(manifest: ByteArray, signatureBytes: ByteArray) {
-        val publicKey = KeyFactory.getInstance("Ed25519").generatePublic(
-            X509EncodedKeySpec(Base64.decode(PUBLIC_KEY_BASE64, Base64.DEFAULT)),
-        )
-        val verifier = Signature.getInstance("Ed25519")
-        verifier.initVerify(publicKey)
-        verifier.update(manifest)
-        require(verifier.verify(signatureBytes)) { context.getString(R.string.repo_signature_failed) }
+        val publicKey = Base64.decode(PUBLIC_KEY_RAW_BASE64, Base64.DEFAULT)
+        require(Ed25519Verifier.verify(publicKey, manifest, signatureBytes)) {
+            context.getString(R.string.repo_signature_failed)
+        }
     }
 
     private fun resolveMainCommit(): String {
@@ -166,8 +160,8 @@ class PayloadRepository(private val context: Context) {
         private const val RAW_REPOSITORY =
             "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads"
         private const val MUTABLE_RAW_PREFIX = "$RAW_REPOSITORY/main/"
-        private const val PUBLIC_KEY_BASE64 =
-            "MCowBQYDK2VwAyEAhg+mmLH+UL+RvioXW6+o34dtZ+3uxvj0Hx4EaQt4B08="
+        private const val PUBLIC_KEY_RAW_BASE64 =
+            "hg+mmLH+UL+RvioXW6+o34dtZ+3uxvj0Hx4EaQt4B08="
         private const val MAX_COMMIT_RESPONSE_BYTES = 16 * 1024
         private const val MAX_MANIFEST_BYTES = 256 * 1024
         private const val MAX_SIGNATURE_BYTES = 1024

--- a/app/src/test/java/dev/busung/s25uroot/Ed25519VerifierTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/Ed25519VerifierTest.kt
@@ -1,0 +1,25 @@
+package dev.busung.s25uroot
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class Ed25519VerifierTest {
+    @Test
+    fun verifiesRfc8032TestVector() {
+        val publicKey = hex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+        val signature = hex(
+            "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e06522490155" +
+                "5fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+        )
+
+        assertTrue(Ed25519Verifier.verify(publicKey, byteArrayOf(), signature))
+
+        signature[0] = (signature[0].toInt() xor 1).toByte()
+        assertFalse(Ed25519Verifier.verify(publicKey, byteArrayOf(), signature))
+    }
+
+    private fun hex(value: String): ByteArray = value.chunked(2)
+        .map { it.toInt(16).toByte() }
+        .toByteArray()
+}


### PR DESCRIPTION
## What changed

- replaced provider-dependent JCA Ed25519 verification with the bundled Bouncy Castle lightweight verifier;
- added RFC 8032 valid and tampered signature tests;
- bumped the app to version 0.2.2 (version code 7).

## Why

Some Samsung firmware selected AndroidKeyStore for `KeyFactory.getInstance("Ed25519")`. AndroidKeyStore cannot import the embedded X.509 public key through `generatePublic`, so support-feed verification stopped before the exploit ran.

## Validation

- `gradlew testDebugUnitTest assembleDebug`
- APK manifest reports version code 7 and version name 0.2.2.
