### PR TITLE
Fix launch crash on proc-restricted devices

### DIFF
--- a/app/src/androidTest/java/dev/busung/s25uroot/PayloadRepositoryTest.kt
+++ b/app/src/androidTest/java/dev/busung/s25uroot/PayloadRepositoryTest.kt
@@ -13,8 +13,10 @@ class PayloadRepositoryTest {
     fun signedManifestMatchesDeviceAndArtifactsDownload() {
         val context = ApplicationProvider.getApplicationContext<android.content.Context>()
         val repository = PayloadRepository(context)
-        val profile = repository.resolveTarget(DeviceSnapshot.current())
-        assertEquals("pa3q-S938NKSUACZF1", profile.profileId)
+        val snapshot = DeviceSnapshot.current()
+        val profile = repository.resolveTarget(snapshot)
+        assertEquals(snapshot.kernelRelease, profile.kernelRelease)
+        assertEquals(snapshot.kernelBuildVersion, profile.kernelBuildVersion)
 
         val payloads = repository.download(profile) { }
         assertEquals(profile.exploit.size, payloads.exploit.length())

--- a/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
+++ b/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
@@ -3,14 +3,13 @@ package dev.busung.s25uroot
 import android.os.Build
 import android.system.Os
 import android.system.OsConstants
-import java.io.File
 
 data class DeviceSnapshot(
     val manufacturer: String,
     val model: String,
     val device: String,
     val kernelRelease: String,
-    val kernelVersion: String,
+    val kernelBuildVersion: String,
     val buildId: String,
     val fingerprint: String,
     val androidRelease: String,
@@ -22,18 +21,21 @@ data class DeviceSnapshot(
         get() = "$kernelRelease / $buildId"
 
     companion object {
-        fun current() = DeviceSnapshot(
-            manufacturer = Build.MANUFACTURER,
-            model = Build.MODEL,
-            device = Build.DEVICE,
-            kernelRelease = Os.uname().release,
-            kernelVersion = File("/proc/version").readText(Charsets.US_ASCII).trim(),
-            buildId = Build.DISPLAY,
-            fingerprint = Build.FINGERPRINT,
-            androidRelease = Build.VERSION.RELEASE,
-            sdk = Build.VERSION.SDK_INT,
-            abi = Build.SUPPORTED_ABIS.firstOrNull().orEmpty(),
-            pageSize = Os.sysconf(OsConstants._SC_PAGESIZE),
-        )
+        fun current(): DeviceSnapshot {
+            val uname = Os.uname()
+            return DeviceSnapshot(
+                manufacturer = Build.MANUFACTURER,
+                model = Build.MODEL,
+                device = Build.DEVICE,
+                kernelRelease = uname.release,
+                kernelBuildVersion = uname.version,
+                buildId = Build.DISPLAY,
+                fingerprint = Build.FINGERPRINT,
+                androidRelease = Build.VERSION.RELEASE,
+                sdk = Build.VERSION.SDK_INT,
+                abi = Build.SUPPORTED_ABIS.firstOrNull().orEmpty(),
+                pageSize = Os.sysconf(OsConstants._SC_PAGESIZE),
+            )
+        }
     }
 }

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -109,7 +109,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                     profiles = repository.loadTargets().sortedWith(
                         compareBy(
                             TargetProfile::kernelRelease,
-                            TargetProfile::kernelVersion,
+                            TargetProfile::kernelBuildVersion,
                             TargetProfile::model,
                             TargetProfile::buildDisplay,
                         ),

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -268,8 +268,8 @@ private fun RootApp(
                     if (warning == CompatibilityWarning.Kernel) {
                         stringResource(
                             R.string.kernel_mismatch_body,
-                            device.kernelVersion,
-                            profile.kernelVersion,
+                            device.kernelBuildVersion,
+                            profile.kernelBuildVersion,
                         )
                     } else {
                         stringResource(R.string.build_mismatch_body, device.buildId, profile.buildDisplay)

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -19,7 +19,7 @@ data class TargetProfile(
     val model: String,
     val device: String,
     val kernelRelease: String,
-    val kernelVersion: String,
+    val kernelBuildVersion: String,
     val buildDisplay: String,
     val buildFingerprint: String,
     val sdk: Int,
@@ -30,7 +30,7 @@ data class TargetProfile(
 ) {
     fun matchesKernel(snapshot: DeviceSnapshot): Boolean =
         kernelRelease == snapshot.kernelRelease &&
-            kernelVersion == snapshot.kernelVersion
+            kernelBuildVersion == snapshot.kernelBuildVersion
 
     fun matches(snapshot: DeviceSnapshot): Boolean =
         matchesKernel(snapshot) &&
@@ -62,7 +62,7 @@ data class SupportManifest(
                             model = target.getString("model"),
                             device = target.getString("device"),
                             kernelRelease = target.getString("kernelRelease"),
-                            kernelVersion = target.getString("kernelVersion"),
+                            kernelBuildVersion = target.getString("kernelBuildVersion"),
                             buildDisplay = target.getString("buildDisplay"),
                             buildFingerprint = target.getString("buildFingerprint"),
                             sdk = target.getInt("sdk"),


### PR DESCRIPTION
## What changed

- reads the kernel release and build version through `Os.uname()`;
- matches the new signed `kernelBuildVersion` target field;
- updates the compatibility warning, sorting, and device-independent instrumentation assertion.

## Root cause

Samsung A155N firmware denies app UIDs access to `/proc/version`. The unhandled `FileNotFoundException` occurred during the first Compose frame and terminated the app.

## Validation

- `gradlew testDebugUnitTest assembleDebug`
- `gradlew lintDebug`
- installed and launched on SM-A155N without a new AndroidRuntime crash;
- A15 target profile loaded from the signed feed on the device;
- user confirmed the corrected screen renders normally.
