### PR TITLE
Tune exploit launch timeouts

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -174,7 +174,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             helper.absolutePath,
             logFile.absolutePath,
         ).redirectErrorStream(true)
-        cachedP0Offset(bootToken)?.let { processBuilder.environment()[P0_OFFSET_ENV] = it }
+        processBuilder.environment().apply {
+            put("EXPLOIT_ATTEMPTS", "24")
+            put("P0_ATTEMPT_TIMEOUT_SEC", "45")
+            put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", "120")
+            cachedP0Offset(bootToken)?.let { put(P0_OFFSET_ENV, it) }
+        }
         val process = processBuilder.start()
 
         try {


### PR DESCRIPTION
## Summary

Adds explicit exploit launch environment settings for app-based installs:

 - `EXPLOIT_ATTEMPTS=24`
 - `P0_ATTEMPT_TIMEOUT_SEC=45`
 - `EXPLOIT_ATTEMPT_TIMEOUT_SEC=120`

The cached P0 offset behavior is preserved.

## Why

The app execution path needs the same forgiving retry/timeout behavior used during successful CLI testing on SM-A566E. Without these settings, app-based runs can fail before the payload gets a stable window.
