### PR TITLE
feat(app): add in-app updater and run history multi-select delete

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <queries>
         <package android:name="me.weishu.kernelsu" />
@@ -15,6 +16,15 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.S25URoot">
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <provider
             android:name="rikka.shizuku.ShizukuProvider"
             android:authorities="${applicationId}.shizuku"

--- a/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
@@ -37,47 +37,39 @@ object AppPreferences {
     private const val CONSUMED_INSTALL_REQUEST = "consumed_install_request"
 
     fun accentColor(context: Context): AccentColor = AccentColor.fromStoredValue(
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .getString(ACCENT_COLOR, null),
+        prefs(context).getString(ACCENT_COLOR, null),
     )
 
     fun setAccentColor(context: Context, color: AccentColor) {
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
+        prefs(context).edit()
             .putString(ACCENT_COLOR, color.storedValue)
             .apply()
     }
 
     fun themeMode(context: Context): AppThemeMode = AppThemeMode.fromStoredValue(
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .getString(THEME_MODE, null),
+        prefs(context).getString(THEME_MODE, null),
     )
 
     fun setThemeMode(context: Context, themeMode: AppThemeMode) {
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
+        prefs(context).edit()
             .putString(THEME_MODE, themeMode.storedValue)
             .apply()
     }
 
     fun advancedMode(context: Context): Boolean =
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .getBoolean(ADVANCED_MODE, false)
+        prefs(context).getBoolean(ADVANCED_MODE, false)
 
     fun setAdvancedMode(context: Context, enabled: Boolean) {
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
+        prefs(context).edit()
             .putBoolean(ADVANCED_MODE, enabled)
             .apply()
     }
 
     fun shizukuMode(context: Context): Boolean =
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .getBoolean(SHIZUKU_MODE, false)
+        prefs(context).getBoolean(SHIZUKU_MODE, false)
 
     fun setShizukuMode(context: Context, enabled: Boolean) {
-        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
-            .edit()
+        prefs(context).edit()
             .putBoolean(SHIZUKU_MODE, enabled)
             .apply()
     }
@@ -85,12 +77,15 @@ object AppPreferences {
     @Synchronized
     fun consumeInstallRequest(context: Context, requestId: String?): Boolean {
         if (requestId.isNullOrBlank()) return false
-        val preferences = context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
+        val preferences = prefs(context)
         if (preferences.getString(CONSUMED_INSTALL_REQUEST, null) == requestId) return false
         return preferences.edit()
             .putString(CONSUMED_INSTALL_REQUEST, requestId)
             .commit()
     }
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE)
 
     fun languageTag(context: Context): String {
         val locales = context.getSystemService(LocaleManager::class.java).applicationLocales

--- a/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
@@ -18,10 +18,12 @@ data class UpdateInfo(
     val releaseUrl: String,
 )
 
+const val ROOT_MY_GALAXY_URL = "https://github.com/BuSung-dev/Root-My-Galaxy"
+
 object AppUpdater {
 
-    private const val GITHUB_API = "https://api.github.com/repos/Busung-Dev/Root-My-Galaxy"
-    private const val RELEASES_PAGE = "https://github.com/Busung-Dev/Root-My-Galaxy/releases/latest"
+    private const val GITHUB_API = "https://api.github.com/repos/BuSung-dev/Root-My-Galaxy"
+    private const val RELEASES_PAGE = "$ROOT_MY_GALAXY_URL/releases/latest"
 
     suspend fun fetchLatestRelease(): UpdateInfo? = withContext(Dispatchers.IO) {
         try {
@@ -61,11 +63,8 @@ object AppUpdater {
         }
     }
 
-    fun isUpdateAvailable(latestVersion: String, currentVersion: String): Boolean {
-        val latest = latestVersion.trim().removePrefix("v")
-        val current = currentVersion.trim().removePrefix("v")
-        return latest.isNotEmpty() && latest != current
-    }
+    fun isUpdateAvailable(latestVersion: String, currentVersion: String): Boolean =
+        latestVersion.isNotEmpty() && latestVersion != currentVersion
 
     suspend fun downloadApk(
         context: Context,

--- a/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
@@ -26,33 +26,36 @@ object AppUpdater {
     suspend fun fetchLatestRelease(): UpdateInfo? = withContext(Dispatchers.IO) {
         try {
             val connection = URL("$GITHUB_API/releases/latest").openConnection() as HttpURLConnection
-            connection.requestMethod = "GET"
-            connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
-            connection.setRequestProperty("Accept", "application/vnd.github+json")
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 10_000
-            if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
-            val body = connection.inputStream.bufferedReader().use { it.readText() }
-            connection.disconnect()
+            try {
+                connection.requestMethod = "GET"
+                connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
+                connection.setRequestProperty("Accept", "application/vnd.github+json")
+                connection.connectTimeout = 10_000
+                connection.readTimeout = 10_000
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
+                val body = connection.inputStream.bufferedReader().use { it.readText() }
 
-            val json = JSONObject(body)
-            val tag = json.optString("tag_name").trim().removePrefix("v")
-            if (tag.isBlank()) return@withContext null
-            var apkUrl: String? = null
-            json.optJSONArray("assets")?.let { assets ->
-                for (i in 0 until assets.length()) {
-                    val asset = assets.getJSONObject(i)
-                    if (asset.optString("name").endsWith(".apk")) {
-                        apkUrl = asset.optString("browser_download_url").ifEmpty { null }
-                        break
+                val json = JSONObject(body)
+                val tag = json.optString("tag_name").trim().removePrefix("v")
+                if (tag.isBlank()) return@withContext null
+                var apkUrl: String? = null
+                json.optJSONArray("assets")?.let { assets ->
+                    for (i in 0 until assets.length()) {
+                        val asset = assets.getJSONObject(i)
+                        if (asset.optString("name").endsWith(".apk")) {
+                            apkUrl = asset.optString("browser_download_url").ifEmpty { null }
+                            break
+                        }
                     }
                 }
+                UpdateInfo(
+                    versionName = tag,
+                    apkUrl = apkUrl,
+                    releaseUrl = json.optString("html_url").ifEmpty { RELEASES_PAGE },
+                )
+            } finally {
+                connection.disconnect()
             }
-            UpdateInfo(
-                versionName = tag,
-                apkUrl = apkUrl,
-                releaseUrl = json.optString("html_url").ifEmpty { RELEASES_PAGE },
-            )
         } catch (_: Exception) {
             null
         }
@@ -69,38 +72,39 @@ object AppUpdater {
         url: String,
         onProgress: (Float) -> Unit = {},
     ): File? = withContext(Dispatchers.IO) {
+        val dir = File(context.cacheDir, "updates").apply { mkdirs() }
+        val target = File(dir, "update.apk")
         try {
-            val dir = File(context.cacheDir, "updates").apply { mkdirs() }
-            val target = File(dir, "update.apk")
             val connection = URL(url).openConnection() as HttpURLConnection
-            connection.requestMethod = "GET"
-            connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
-            connection.connectTimeout = 15_000
-            connection.readTimeout = 30_000
-            if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
-            val total = connection.contentLength
-            val buffer = ByteArray(64 * 1024)
-            var downloaded = 0L
-            connection.inputStream.use { input ->
-                target.outputStream().use { output ->
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        output.write(buffer, 0, read)
-                        downloaded += read
-                        if (total > 0) {
-                            onProgress((downloaded.toFloat() / total).coerceIn(0f, 1f))
+            try {
+                connection.requestMethod = "GET"
+                connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
+                connection.connectTimeout = 15_000
+                connection.readTimeout = 30_000
+                if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
+                val total = connection.contentLength
+                val buffer = ByteArray(64 * 1024)
+                var downloaded = 0L
+                connection.inputStream.use { input ->
+                    target.outputStream().use { output ->
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            output.write(buffer, 0, read)
+                            downloaded += read
+                            if (total > 0) {
+                                onProgress((downloaded.toFloat() / total).coerceIn(0f, 1f))
+                            }
                         }
                     }
                 }
+                if (target.length() == 0L) return@withContext null
+                target
+            } finally {
+                connection.disconnect()
             }
-            connection.disconnect()
-            if (target.length() == 0L) {
-                target.delete()
-                return@withContext null
-            }
-            target
         } catch (_: Exception) {
+            target.delete()
             null
         }
     }

--- a/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppUpdater.kt
@@ -1,0 +1,125 @@
+package dev.busung.s25uroot
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+data class UpdateInfo(
+    val versionName: String,
+    val apkUrl: String?,
+    val releaseUrl: String,
+)
+
+object AppUpdater {
+
+    private const val GITHUB_API = "https://api.github.com/repos/Busung-Dev/Root-My-Galaxy"
+    private const val RELEASES_PAGE = "https://github.com/Busung-Dev/Root-My-Galaxy/releases/latest"
+
+    suspend fun fetchLatestRelease(): UpdateInfo? = withContext(Dispatchers.IO) {
+        try {
+            val connection = URL("$GITHUB_API/releases/latest").openConnection() as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
+            connection.setRequestProperty("Accept", "application/vnd.github+json")
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 10_000
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
+            val body = connection.inputStream.bufferedReader().use { it.readText() }
+            connection.disconnect()
+
+            val json = JSONObject(body)
+            val tag = json.optString("tag_name").trim().removePrefix("v")
+            if (tag.isBlank()) return@withContext null
+            var apkUrl: String? = null
+            json.optJSONArray("assets")?.let { assets ->
+                for (i in 0 until assets.length()) {
+                    val asset = assets.getJSONObject(i)
+                    if (asset.optString("name").endsWith(".apk")) {
+                        apkUrl = asset.optString("browser_download_url").ifEmpty { null }
+                        break
+                    }
+                }
+            }
+            UpdateInfo(
+                versionName = tag,
+                apkUrl = apkUrl,
+                releaseUrl = json.optString("html_url").ifEmpty { RELEASES_PAGE },
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun isUpdateAvailable(latestVersion: String, currentVersion: String): Boolean {
+        val latest = latestVersion.trim().removePrefix("v")
+        val current = currentVersion.trim().removePrefix("v")
+        return latest.isNotEmpty() && latest != current
+    }
+
+    suspend fun downloadApk(
+        context: Context,
+        url: String,
+        onProgress: (Float) -> Unit = {},
+    ): File? = withContext(Dispatchers.IO) {
+        try {
+            val dir = File(context.cacheDir, "updates").apply { mkdirs() }
+            val target = File(dir, "update.apk")
+            val connection = URL(url).openConnection() as HttpURLConnection
+            connection.requestMethod = "GET"
+            connection.setRequestProperty("User-Agent", "RootMyGalaxy/${BuildConfig.VERSION_NAME}")
+            connection.connectTimeout = 15_000
+            connection.readTimeout = 30_000
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) return@withContext null
+            val total = connection.contentLength
+            val buffer = ByteArray(64 * 1024)
+            var downloaded = 0L
+            connection.inputStream.use { input ->
+                target.outputStream().use { output ->
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        downloaded += read
+                        if (total > 0) {
+                            onProgress((downloaded.toFloat() / total).coerceIn(0f, 1f))
+                        }
+                    }
+                }
+            }
+            connection.disconnect()
+            if (target.length() == 0L) {
+                target.delete()
+                return@withContext null
+            }
+            target
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun installApk(context: Context, apk: File): Boolean {
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", apk)
+        return try {
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, "application/vnd.android.package-archive")
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(intent)
+            true
+        } catch (_: ActivityNotFoundException) {
+            false
+        }
+    }
+
+    fun openReleasesPage(context: Context) {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(RELEASES_PAGE)))
+    }
+}

--- a/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
+++ b/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
@@ -9,6 +9,8 @@ data class DeviceSnapshot(
     val model: String,
     val device: String,
     val kernelRelease: String,
+    val kernelVersionInfo: String,
+    val machine: String,
     val buildId: String,
     val fingerprint: String,
     val androidRelease: String,
@@ -19,6 +21,11 @@ data class DeviceSnapshot(
     val kernelVersion: String
         get() = kernelRelease.takeWhile { it.isDigit() || it == '.' }
 
+    val kernelVersionFull: String
+        get() = listOf(kernelRelease, kernelVersionInfo, machine)
+            .filter(String::isNotBlank)
+            .joinToString(" ")
+
     companion object {
         fun current(): DeviceSnapshot {
             val uname = Os.uname()
@@ -27,6 +34,8 @@ data class DeviceSnapshot(
                 model = Build.MODEL,
                 device = Build.DEVICE,
                 kernelRelease = uname.release,
+                kernelVersionInfo = uname.version,
+                machine = uname.machine,
                 buildId = Build.DISPLAY,
                 fingerprint = Build.FINGERPRINT,
                 androidRelease = Build.VERSION.RELEASE,

--- a/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
+++ b/app/src/main/java/dev/busung/s25uroot/DeviceSnapshot.kt
@@ -16,9 +16,6 @@ data class DeviceSnapshot(
     val abi: String,
     val pageSize: Long,
 ) {
-    val targetLabel: String
-        get() = "$kernelRelease / $buildId"
-
     val kernelVersion: String
         get() = kernelRelease.takeWhile { it.isDigit() || it == '.' }
 

--- a/app/src/main/java/dev/busung/s25uroot/InstallActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallActivity.kt
@@ -1,6 +1,9 @@
 package dev.busung.s25uroot
 
+import android.os.Build
 import android.os.Bundle
+import android.view.HapticFeedbackConstants
+import android.view.View
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -47,6 +50,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontFamily
@@ -108,6 +112,16 @@ internal val installerSteps = listOf(
     InstallerStep(R.string.step_ksu_title, R.string.step_ksu_detail, Icons.Rounded.Check),
 )
 
+private fun clickHaptic(view: View) {
+    view.performHapticFeedback(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            HapticFeedbackConstants.CONFIRM
+        } else {
+            HapticFeedbackConstants.LONG_PRESS
+        },
+    )
+}
+
 @Composable
 private fun InstallScreen(
     installState: InstallUiState,
@@ -115,6 +129,7 @@ private fun InstallScreen(
     onClose: () -> Unit,
 ) {
     val logScrollState = rememberScrollState()
+    val view = LocalView.current
     LaunchedEffect(installState.log) {
         delay(40)
         logScrollState.scrollTo(logScrollState.maxValue)
@@ -163,20 +178,29 @@ private fun InstallScreen(
                 ) {
                     if (installState.phase == InstallPhase.Failed) {
                         FilledTonalButton(
-                            onClick = onClose,
+                            onClick = {
+                                clickHaptic(view)
+                                onClose()
+                            },
                             modifier = Modifier.weight(1f),
                         ) {
                             Text(stringResource(R.string.action_close))
                         }
                         Button(
-                            onClick = onRetry,
+                            onClick = {
+                                clickHaptic(view)
+                                onRetry()
+                            },
                             modifier = Modifier.weight(1f),
                         ) {
                             Text(stringResource(R.string.action_retry))
                         }
                     } else if (installState.phase == InstallPhase.Installed) {
                         Button(
-                            onClick = onClose,
+                            onClick = {
+                                clickHaptic(view)
+                                onClose()
+                            },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Text(stringResource(R.string.action_done))

--- a/app/src/main/java/dev/busung/s25uroot/InstallHistory.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallHistory.kt
@@ -66,6 +66,10 @@ class InstallHistoryStore(private val context: Context) {
         }
     }
 
+    fun delete(id: String) {
+        File(directory, "$id.json").delete()
+    }
+
     private fun encode(entry: InstallHistoryEntry) = JSONObject()
         .put("id", entry.id)
         .put("startedAtMillis", entry.startedAtMillis)

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -102,6 +102,11 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
+    fun deleteHistoryEntries(ids: Collection<String>) {
+        ids.forEach(historyStore::delete)
+        mutableHistory.value = historyStore.load()
+    }
+
     fun loadTargetCatalog() {
         if (mutableTargetCatalog.value.loading) return
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -103,8 +103,11 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     }
 
     fun deleteHistoryEntries(ids: Collection<String>) {
-        ids.forEach(historyStore::delete)
-        mutableHistory.value = historyStore.load()
+        val runningId = activeHistoryEntry?.id
+        val toDelete = ids.filterNot { it == runningId }
+        if (toDelete.isEmpty()) return
+        toDelete.forEach(historyStore::delete)
+        mutableHistory.value = mutableHistory.value.filterNot { it.id in toDelete }
     }
 
     fun loadTargetCatalog() {

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -209,8 +209,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             ).redirectErrorStream(true)
             processBuilder.environment().apply {
                 put("EXPLOIT_ATTEMPTS", EXPLOIT_ATTEMPTS)
-                put("P0_ATTEMPT_TIMEOUT_SEC", "45")
-                put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", "120")
+                put("P0_ATTEMPT_TIMEOUT_SEC", P0_ATTEMPT_TIMEOUT_SEC)
+                put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", EXPLOIT_ATTEMPT_TIMEOUT_SEC)
                 cachedP0Offset(bootToken)?.let { put(P0_OFFSET_ENV, it) }
             }
             processBuilder.start()
@@ -401,8 +401,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         helperPath: String,
     ): Array<String> = buildList {
         add("EXPLOIT_ATTEMPTS=$EXPLOIT_ATTEMPTS")
-        add("P0_ATTEMPT_TIMEOUT_SEC=45")
-        add("EXPLOIT_ATTEMPT_TIMEOUT_SEC=120")
+        add("P0_ATTEMPT_TIMEOUT_SEC=$P0_ATTEMPT_TIMEOUT_SEC")
+        add("EXPLOIT_ATTEMPT_TIMEOUT_SEC=$EXPLOIT_ATTEMPT_TIMEOUT_SEC")
         add("CVE43499_ROOT_HELPER=$helperPath")
         add("LD_PRELOAD=$payloadPath")
         cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
@@ -449,32 +449,29 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         publishHistory(entry)
     }
 
-    private fun updateHistoryLog() {
+    private fun updateHistory(transform: (InstallHistoryEntry) -> InstallHistoryEntry) {
         val entry = activeHistoryEntry ?: return
-        val updated = entry.copy(log = mutableState.value.log)
+        val updated = transform(entry)
         activeHistoryEntry = updated
         historyStore.save(updated)
         publishHistory(updated)
     }
 
-    private fun updateHistoryProfile(profileId: String) {
-        val entry = activeHistoryEntry ?: return
-        val updated = entry.copy(profileId = profileId)
-        activeHistoryEntry = updated
-        historyStore.save(updated)
-        publishHistory(updated)
-    }
+    private fun updateHistoryLog() =
+        updateHistory { it.copy(log = mutableState.value.log) }
+
+    private fun updateHistoryProfile(profileId: String) =
+        updateHistory { it.copy(profileId = profileId) }
 
     private fun finishHistory(result: InstallRunResult) {
-        val entry = activeHistoryEntry ?: return
-        val completed = entry.copy(
-            completedAtMillis = System.currentTimeMillis(),
-            result = result,
-            log = mutableState.value.log,
-        )
+        updateHistory { entry ->
+            entry.copy(
+                completedAtMillis = System.currentTimeMillis(),
+                result = result,
+                log = mutableState.value.log,
+            )
+        }
         activeHistoryEntry = null
-        historyStore.save(completed)
-        publishHistory(completed)
     }
 
     private fun publishHistory(entry: InstallHistoryEntry) {
@@ -486,6 +483,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
     companion object {
         private const val EXPLOIT_ATTEMPTS = "24"
+        private const val P0_ATTEMPT_TIMEOUT_SEC = "45"
+        private const val EXPLOIT_ATTEMPT_TIMEOUT_SEC = "120"
         private const val EXPLOIT_STALL_MILLIS = 90_000L
         private const val EXPLOIT_TOTAL_MILLIS = 900_000L
         private const val INSTALL_RECEIPT = "install_receipt"

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -813,8 +813,9 @@ private fun InstallStatusCard(installState: InstallUiState, onInstall: () -> Uni
 
 @Composable
 private fun DeviceCard(device: DeviceSnapshot) {
+    var kernelExpanded by remember { mutableStateOf(false) }
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().animateContentSize(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -827,14 +828,35 @@ private fun DeviceCard(device: DeviceSnapshot) {
             InfoRow(Icons.Rounded.Memory, stringResource(R.string.device), "${device.manufacturer} ${device.model} (${device.device})")
             InfoRow(Icons.Rounded.Code, stringResource(R.string.firmware), device.buildId)
             InfoRow(Icons.Rounded.Info, stringResource(R.string.system), "Android ${device.androidRelease} (API ${device.sdk})")
+            InfoRow(
+                icon = Icons.Rounded.Info,
+                label = stringResource(R.string.kernel),
+                value = if (kernelExpanded) device.kernelVersionFull else device.kernelRelease,
+                onClick = { kernelExpanded = !kernelExpanded },
+            )
             InfoRow(Icons.Rounded.Security, stringResource(R.string.system_abi), "${device.abi} (${device.pageSize / 1024}K)")
         }
     }
 }
 
 @Composable
-private fun InfoRow(icon: ImageVector, label: String, value: String) {
-    Row(horizontalArrangement = Arrangement.spacedBy(13.dp)) {
+private fun InfoRow(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    onClick: (() -> Unit)? = null,
+) {
+    Row(
+        modifier = if (onClick != null) {
+            Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.medium)
+                .clickable(onClick = onClick)
+        } else {
+            Modifier
+        },
+        horizontalArrangement = Arrangement.spacedBy(13.dp),
+    ) {
         Icon(icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
         Column {
             Text(label, style = MaterialTheme.typography.titleSmall)

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -86,6 +86,7 @@ import androidx.compose.material3.ButtonGroupDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledTonalButton
@@ -111,7 +112,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -144,7 +144,6 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.busung.s25uroot.ui.theme.RootMyGalaxyTheme
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.DateFormat
@@ -289,11 +288,12 @@ private fun RootApp(
     var selectedProfile by remember { mutableStateOf<TargetProfile?>(null) }
     var compatibilityWarning by remember { mutableStateOf<CompatibilityWarning?>(null) }
     val device = remember { DeviceSnapshot.current() }
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var updateStatus by remember { mutableStateOf<UpdateStatus>(UpdateStatus.Idle) }
     var updateCardDismissed by remember { mutableStateOf(false) }
     val checkForUpdate: () -> Unit = {
-        if (updateStatus !is UpdateStatus.Checking) {
+        if (updateStatus !is UpdateStatus.Checking && updateStatus !is UpdateStatus.Downloading) {
             updateStatus = UpdateStatus.Checking
             scope.launch {
                 val info = AppUpdater.fetchLatestRelease()
@@ -303,6 +303,24 @@ private fun RootApp(
                         UpdateStatus.Available(info)
                     else -> UpdateStatus.UpToDate
                 }
+            }
+        }
+    }
+    val startDownload: (UpdateInfo) -> Unit = { info ->
+        val apkUrl = info.apkUrl
+        if (apkUrl == null) {
+            AppUpdater.openReleasesPage(context)
+        } else {
+            updateStatus = UpdateStatus.Downloading(info, 0f)
+            scope.launch {
+                val apk = AppUpdater.downloadApk(context, apkUrl) { progress ->
+                    updateStatus = UpdateStatus.Downloading(info, progress)
+                }
+                if (apk == null || !AppUpdater.installApk(context, apk)) {
+                    Toast.makeText(context, context.getString(R.string.updater_download_failed), Toast.LENGTH_SHORT).show()
+                    AppUpdater.openReleasesPage(context)
+                }
+                updateStatus = UpdateStatus.Available(info)
             }
         }
     }
@@ -446,6 +464,7 @@ private fun RootApp(
                     updateStatus = updateStatus,
                     updateCardDismissed = updateCardDismissed,
                     onDismissUpdateCard = { updateCardDismissed = true },
+                    onStartDownload = startDownload,
                     onInstall = {
                         selectedProfile = null
                         if (advancedMode) {
@@ -469,6 +488,7 @@ private fun RootApp(
                     shizukuMode = shizukuMode,
                     updateStatus = updateStatus,
                     onCheckForUpdate = checkForUpdate,
+                    onStartDownload = startDownload,
                     onAccentColorChanged = onAccentColorChanged,
                     onThemeModeChanged = onThemeModeChanged,
                     onAdvancedModeChanged = onAdvancedModeChanged,
@@ -493,6 +513,7 @@ private fun OverviewPage(
     updateStatus: UpdateStatus,
     updateCardDismissed: Boolean,
     onDismissUpdateCard: () -> Unit,
+    onStartDownload: (UpdateInfo) -> Unit,
     onInstall: () -> Unit,
 ) {
     LazyColumn(
@@ -529,8 +550,17 @@ private fun OverviewPage(
                 )
             }
         }
-        if (updateStatus is UpdateStatus.Available && !updateCardDismissed) {
-            item { UpdateCard(updateStatus.info, onDismiss = onDismissUpdateCard) }
+        if (
+            !updateCardDismissed &&
+            (updateStatus is UpdateStatus.Available || updateStatus is UpdateStatus.Downloading)
+        ) {
+            item {
+                UpdateCard(
+                    status = updateStatus,
+                    onDismiss = onDismissUpdateCard,
+                    onStartDownload = onStartDownload,
+                )
+            }
         }
         item { InstallStatusCard(installState, onInstall) }
         item { DeviceCard(device) }
@@ -542,40 +572,23 @@ private sealed interface UpdateStatus {
     data object Idle : UpdateStatus
     data object Checking : UpdateStatus
     data class Available(val info: UpdateInfo) : UpdateStatus
+    data class Downloading(val info: UpdateInfo, val progress: Float) : UpdateStatus
     data object UpToDate : UpdateStatus
     data object Failed : UpdateStatus
 }
 
-private fun launchUpdateDownload(
-    context: Context,
-    scope: CoroutineScope,
-    info: UpdateInfo,
-    downloadFailedMessage: String,
-    onDownloadingChange: (Boolean) -> Unit,
-    onProgress: (Float) -> Unit,
-) {
-    val apkUrl = info.apkUrl
-    if (apkUrl == null) {
-        AppUpdater.openReleasesPage(context)
-        return
-    }
-    onDownloadingChange(true)
-    scope.launch {
-        val apk = AppUpdater.downloadApk(context, apkUrl, onProgress = onProgress)
-        onDownloadingChange(false)
-        if (apk != null && AppUpdater.installApk(context, apk)) return@launch
-        Toast.makeText(context, downloadFailedMessage, Toast.LENGTH_SHORT).show()
-        AppUpdater.openReleasesPage(context)
-    }
-}
-
 @Composable
-private fun UpdateCard(info: UpdateInfo, onDismiss: () -> Unit) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val downloadFailed = stringResource(R.string.updater_download_failed)
-    var downloading by remember { mutableStateOf(false) }
-    var progress by remember { mutableFloatStateOf(0f) }
+private fun UpdateCard(
+    status: UpdateStatus,
+    onDismiss: () -> Unit,
+    onStartDownload: (UpdateInfo) -> Unit,
+) {
+    val info = when (status) {
+        is UpdateStatus.Available -> status.info
+        is UpdateStatus.Downloading -> status.info
+        else -> null
+    }
+    if (info == null) return
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -617,34 +630,25 @@ private fun UpdateCard(info: UpdateInfo, onDismiss: () -> Unit) {
                 text = stringResource(R.string.updater_available_body, info.versionName),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            if (downloading) {
-                LinearProgressIndicator(
-                    progress = { progress },
-                    modifier = Modifier.fillMaxWidth(),
-                    color = LocalContentColor.current,
-                    trackColor = LocalContentColor.current.copy(alpha = 0.2f),
-                    drawStopIndicator = {},
-                )
-                Text(
-                    text = stringResource(R.string.updater_downloading),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = LocalContentColor.current.copy(alpha = 0.78f),
-                )
-            } else {
-                FilledTonalButton(
-                    onClick = {
-                        progress = 0f
-                        launchUpdateDownload(
-                            context = context,
-                            scope = scope,
-                            info = info,
-                            downloadFailedMessage = downloadFailed,
-                            onDownloadingChange = { downloading = it },
-                            onProgress = { p -> scope.launch { progress = p } },
-                        )
-                    },
-                ) {
-                    Text(stringResource(R.string.updater_button_download))
+            when (status) {
+                is UpdateStatus.Downloading -> {
+                    LinearProgressIndicator(
+                        progress = { status.progress },
+                        modifier = Modifier.fillMaxWidth(),
+                        color = LocalContentColor.current,
+                        trackColor = LocalContentColor.current.copy(alpha = 0.2f),
+                        drawStopIndicator = {},
+                    )
+                    Text(
+                        text = stringResource(R.string.updater_downloading),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = LocalContentColor.current.copy(alpha = 0.78f),
+                    )
+                }
+                else -> {
+                    FilledTonalButton(onClick = { onStartDownload(info) }) {
+                        Text(stringResource(R.string.updater_button_download))
+                    }
                 }
             }
         }
@@ -1300,6 +1304,7 @@ private fun SettingsPage(
     shizukuMode: Boolean,
     updateStatus: UpdateStatus,
     onCheckForUpdate: () -> Unit,
+    onStartDownload: (UpdateInfo) -> Unit,
     onAccentColorChanged: (AccentColor) -> Unit,
     onThemeModeChanged: (AppThemeMode) -> Unit,
     onAdvancedModeChanged: (Boolean) -> Unit,
@@ -1461,6 +1466,7 @@ private fun SettingsPage(
                     status = updateStatus,
                     position = SettingsCardPosition.Top,
                     onCheckForUpdate = onCheckForUpdate,
+                    onStartDownload = onStartDownload,
                 )
                 SettingsCard(
                     icon = Icons.Rounded.Info,
@@ -1480,25 +1486,15 @@ private fun UpdateSettingsCard(
     status: UpdateStatus,
     position: SettingsCardPosition,
     onCheckForUpdate: () -> Unit,
+    onStartDownload: (UpdateInfo) -> Unit,
 ) {
-    val context = LocalContext.current
-    val scope = rememberCoroutineScope()
-    val downloadFailed = stringResource(R.string.updater_download_failed)
-    var downloading by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
-    val busy = downloading || status is UpdateStatus.Checking
+    val busy = status is UpdateStatus.Checking || status is UpdateStatus.Downloading
     Card(
         onClick = {
             when {
                 busy -> Unit
-                status is UpdateStatus.Available -> launchUpdateDownload(
-                    context = context,
-                    scope = scope,
-                    info = status.info,
-                    downloadFailedMessage = downloadFailed,
-                    onDownloadingChange = { downloading = it },
-                    onProgress = {},
-                )
+                status is UpdateStatus.Available -> onStartDownload(status.info)
                 else -> onCheckForUpdate()
             }
         },
@@ -1514,10 +1510,13 @@ private fun UpdateSettingsCard(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            if (status is UpdateStatus.Checking) {
-                LoadingIndicator(modifier = Modifier.size(28.dp))
-            } else {
-                Icon(
+            when {
+                status is UpdateStatus.Checking -> LoadingIndicator(modifier = Modifier.size(28.dp))
+                status is UpdateStatus.Downloading -> CircularProgressIndicator(
+                    progress = { status.progress },
+                    modifier = Modifier.size(28.dp),
+                )
+                else -> Icon(
                     Icons.Rounded.SystemUpdate,
                     contentDescription = null,
                     modifier = Modifier.size(28.dp),
@@ -1526,20 +1525,21 @@ private fun UpdateSettingsCard(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = when (status) {
-                        is UpdateStatus.Available -> stringResource(R.string.updater_available_title)
+                        is UpdateStatus.Available, is UpdateStatus.Downloading ->
+                            stringResource(R.string.updater_available_title)
                         else -> stringResource(R.string.updater_check)
                     },
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Text(
                     text = when {
-                        downloading -> stringResource(R.string.updater_downloading)
+                        status is UpdateStatus.Downloading -> stringResource(R.string.updater_downloading)
                         status is UpdateStatus.Checking -> stringResource(R.string.updater_checking)
                         status is UpdateStatus.Available ->
                             stringResource(R.string.updater_available_body_short, status.info.versionName)
-                        status == UpdateStatus.UpToDate -> stringResource(R.string.updater_up_to_date)
-                        status == UpdateStatus.Failed -> stringResource(R.string.updater_failed)
-                        else -> stringResource(R.string.updater_check)
+                        status is UpdateStatus.UpToDate -> stringResource(R.string.updater_up_to_date)
+                        status is UpdateStatus.Failed -> stringResource(R.string.updater_failed)
+                        else -> ""
                     },
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -135,6 +135,7 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
@@ -293,7 +294,7 @@ private fun RootApp(
     var updateStatus by remember { mutableStateOf<UpdateStatus>(UpdateStatus.Idle) }
     var updateCardDismissed by remember { mutableStateOf(false) }
     val checkForUpdate: () -> Unit = {
-        if (updateStatus !is UpdateStatus.Checking && updateStatus !is UpdateStatus.Downloading) {
+        if (!updateStatus.busy) {
             updateStatus = UpdateStatus.Checking
             scope.launch {
                 val info = AppUpdater.fetchLatestRelease()
@@ -500,6 +501,22 @@ private fun RootApp(
 }
 
 @Composable
+private fun AppVersionText(
+    style: TextStyle,
+    color: Color,
+) {
+    Text(
+        text = stringResource(
+            R.string.version_format,
+            BuildConfig.VERSION_NAME,
+            BuildConfig.VERSION_CODE,
+        ),
+        style = style,
+        color = color,
+    )
+}
+
+@Composable
 private fun DialogDimAmount(amount: Float) {
     val window = (LocalView.current.parent as DialogWindowProvider).window
     SideEffect { window.setDimAmount(amount) }
@@ -539,12 +556,7 @@ private fun OverviewPage(
                     style = MaterialTheme.typography.headlineLarge,
                 )
                 Spacer(modifier = Modifier.weight(1f))
-                Text(
-                    text = stringResource(
-                        R.string.version_format,
-                        BuildConfig.VERSION_NAME,
-                        BuildConfig.VERSION_CODE,
-                    ),
+                AppVersionText(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
                 )
@@ -552,7 +564,7 @@ private fun OverviewPage(
         }
         if (
             !updateCardDismissed &&
-            (updateStatus is UpdateStatus.Available || updateStatus is UpdateStatus.Downloading)
+            updateStatus.info != null
         ) {
             item {
                 UpdateCard(
@@ -577,17 +589,23 @@ private sealed interface UpdateStatus {
     data object Failed : UpdateStatus
 }
 
+private val UpdateStatus.busy: Boolean
+    get() = this is UpdateStatus.Checking || this is UpdateStatus.Downloading
+
+private val UpdateStatus.info: UpdateInfo?
+    get() = when (this) {
+        is UpdateStatus.Available -> this.info
+        is UpdateStatus.Downloading -> this.info
+        else -> null
+    }
+
 @Composable
 private fun UpdateCard(
     status: UpdateStatus,
     onDismiss: () -> Unit,
     onStartDownload: (UpdateInfo) -> Unit,
 ) {
-    val info = when (status) {
-        is UpdateStatus.Available -> status.info
-        is UpdateStatus.Downloading -> status.info
-        else -> null
-    }
+    val info = status.info
     if (info == null) return
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -1049,16 +1067,8 @@ private fun HistoryEntryCard(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val shape = expressiveClickableCardShape(interactionSource)
-    val containerColor = when (entry.result) {
-        InstallRunResult.Running -> MaterialTheme.colorScheme.tertiaryContainer
-        InstallRunResult.Succeeded -> MaterialTheme.colorScheme.primaryContainer
-        InstallRunResult.Failed -> MaterialTheme.colorScheme.errorContainer
-    }
-    val contentColor = when (entry.result) {
-        InstallRunResult.Running -> MaterialTheme.colorScheme.onTertiaryContainer
-        InstallRunResult.Succeeded -> MaterialTheme.colorScheme.onPrimaryContainer
-        InstallRunResult.Failed -> MaterialTheme.colorScheme.onErrorContainer
-    }
+    val containerColor = historyResultContainerColor(entry.result)
+    val contentColor = historyResultContentColor(entry.result)
     val borderWidth by animateDpAsState(
         targetValue = if (selectionMode && isSelected) 2.dp else 0.dp,
         label = "history-card-border",
@@ -1189,16 +1199,8 @@ private fun HistoryDetail(
 
 @Composable
 private fun HistoryResultCard(entry: InstallHistoryEntry) {
-    val containerColor = when (entry.result) {
-        InstallRunResult.Running -> MaterialTheme.colorScheme.tertiaryContainer
-        InstallRunResult.Succeeded -> MaterialTheme.colorScheme.primaryContainer
-        InstallRunResult.Failed -> MaterialTheme.colorScheme.errorContainer
-    }
-    val contentColor = when (entry.result) {
-        InstallRunResult.Running -> MaterialTheme.colorScheme.onTertiaryContainer
-        InstallRunResult.Succeeded -> MaterialTheme.colorScheme.onPrimaryContainer
-        InstallRunResult.Failed -> MaterialTheme.colorScheme.onErrorContainer
-    }
+    val containerColor = historyResultContainerColor(entry.result)
+    val contentColor = historyResultContentColor(entry.result)
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
@@ -1260,6 +1262,20 @@ private fun historyResultIcon(result: InstallRunResult): ImageVector = when (res
     InstallRunResult.Running -> Icons.Rounded.Schedule
     InstallRunResult.Succeeded -> Icons.Rounded.CheckCircle
     InstallRunResult.Failed -> Icons.Rounded.Error
+}
+
+@Composable
+private fun historyResultContainerColor(result: InstallRunResult): Color = when (result) {
+    InstallRunResult.Running -> MaterialTheme.colorScheme.tertiaryContainer
+    InstallRunResult.Succeeded -> MaterialTheme.colorScheme.primaryContainer
+    InstallRunResult.Failed -> MaterialTheme.colorScheme.errorContainer
+}
+
+@Composable
+private fun historyResultContentColor(result: InstallRunResult): Color = when (result) {
+    InstallRunResult.Running -> MaterialTheme.colorScheme.onTertiaryContainer
+    InstallRunResult.Succeeded -> MaterialTheme.colorScheme.onPrimaryContainer
+    InstallRunResult.Failed -> MaterialTheme.colorScheme.onErrorContainer
 }
 
 @Composable
@@ -1349,10 +1365,8 @@ private fun SettingsPage(
     if (showLanguageDialog) {
         SideChoiceMenu(
             choices = languageOptions.map { stringResource(it.label) },
-            selectedIndex = languageOptions.indexOfFirst {
-                it.tag.isEmpty() && currentLanguageTag.isEmpty() ||
-                    it.tag.isNotEmpty() && currentLanguageTag.startsWith(it.tag.substringBefore('-'))
-            }.coerceAtLeast(0),
+            selectedIndex = languageOptions.indexOfFirst { languageMatches(it, currentLanguageTag) }
+                .coerceAtLeast(0),
             topOffset = languageMenuTop,
             onSelected = { index ->
                 showLanguageDialog = false
@@ -1388,8 +1402,7 @@ private fun SettingsPage(
         item {
             Column(modifier = Modifier.padding(top = 20.dp, bottom = 18.dp)) {
                 Text(stringResource(R.string.settings), style = MaterialTheme.typography.headlineLarge)
-                Text(
-                    stringResource(R.string.version_format, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE),
+                AppVersionText(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -1489,7 +1502,7 @@ private fun UpdateSettingsCard(
     onStartDownload: (UpdateInfo) -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
-    val busy = status is UpdateStatus.Checking || status is UpdateStatus.Downloading
+    val busy = status.busy
     Card(
         onClick = {
             when {
@@ -1869,8 +1882,7 @@ private fun AboutDialog(onDismiss: () -> Unit) {
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
                 Text(stringResource(R.string.about_body))
-                Text(
-                    stringResource(R.string.version_format, BuildConfig.VERSION_NAME, BuildConfig.VERSION_CODE),
+                AppVersionText(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -2121,21 +2133,16 @@ private fun SideChoiceMenu(
 
 private const val MENU_EXIT_ANIMATION_MILLIS = 180
 private const val MENU_EXIT_WAIT_MILLIS = 200L
-private const val ROOT_MY_GALAXY_URL = "https://github.com/BuSung-dev/Root-My-Galaxy"
 
 @Composable
-private fun languageLabel(tag: String): String = when {
-    tag.startsWith("ko") -> stringResource(R.string.language_korean)
-    tag.startsWith("en") -> stringResource(R.string.language_english)
-    tag.startsWith("ja") -> stringResource(R.string.language_japanese)
-    tag.startsWith("zh-TW") -> stringResource(R.string.language_chinese_traditional)
-    tag.startsWith("zh") -> stringResource(R.string.language_chinese)
-    tag.startsWith("tr") -> stringResource(R.string.language_turkish)
-    tag.startsWith("pt-BR") -> stringResource(R.string.language_brazillian_portuguese)
-    tag.startsWith("ru") -> stringResource(R.string.language_russian)
-    tag.startsWith("vi") -> stringResource(R.string.language_vietnamese)
-    tag.startsWith("uz") -> stringResource(R.string.language_uzbek)
-    else -> stringResource(R.string.language_system)
+private fun languageLabel(tag: String): String =
+    languageOptions.firstOrNull { languageMatches(it, tag) }
+        ?.let { stringResource(it.label) }
+        ?: stringResource(R.string.language_system)
+
+private fun languageMatches(option: LanguageOption, currentTag: String): Boolean {
+    if (option.tag.isEmpty()) return currentTag.isEmpty()
+    return currentTag == option.tag || currentTag.startsWith("$option.tag-")
 }
 
 @Composable

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -15,7 +15,9 @@ import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
@@ -24,7 +26,9 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
@@ -57,6 +61,9 @@ import androidx.compose.material.icons.rounded.Code
 import androidx.compose.material.icons.rounded.BrightnessAuto
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.SelectAll
 import androidx.compose.material.icons.rounded.Error
 import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.History
@@ -68,6 +75,7 @@ import androidx.compose.material.icons.rounded.Memory
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.SystemUpdate
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.VerifiedUser
@@ -79,11 +87,14 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.NavigationBar
@@ -100,11 +111,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
@@ -115,6 +128,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
@@ -130,6 +144,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.busung.s25uroot.ui.theme.RootMyGalaxyTheme
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.text.DateFormat
@@ -274,6 +289,24 @@ private fun RootApp(
     var selectedProfile by remember { mutableStateOf<TargetProfile?>(null) }
     var compatibilityWarning by remember { mutableStateOf<CompatibilityWarning?>(null) }
     val device = remember { DeviceSnapshot.current() }
+    val scope = rememberCoroutineScope()
+    var updateStatus by remember { mutableStateOf<UpdateStatus>(UpdateStatus.Idle) }
+    var updateCardDismissed by remember { mutableStateOf(false) }
+    val checkForUpdate: () -> Unit = {
+        if (updateStatus !is UpdateStatus.Checking) {
+            updateStatus = UpdateStatus.Checking
+            scope.launch {
+                val info = AppUpdater.fetchLatestRelease()
+                updateStatus = when {
+                    info == null -> UpdateStatus.Failed
+                    AppUpdater.isUpdateAvailable(info.versionName, BuildConfig.VERSION_NAME) ->
+                        UpdateStatus.Available(info)
+                    else -> UpdateStatus.UpToDate
+                }
+            }
+        }
+    }
+    LaunchedEffect(Unit) { checkForUpdate() }
 
     if (showTargetPicker) {
         TargetSelectionSheet(
@@ -410,6 +443,9 @@ private fun RootApp(
                     padding = padding,
                     device = device,
                     installState = installState,
+                    updateStatus = updateStatus,
+                    updateCardDismissed = updateCardDismissed,
+                    onDismissUpdateCard = { updateCardDismissed = true },
                     onInstall = {
                         selectedProfile = null
                         if (advancedMode) {
@@ -420,13 +456,19 @@ private fun RootApp(
                         }
                     },
                 )
-                AppPage.History -> HistoryPage(padding, history)
+                AppPage.History -> HistoryPage(
+                    padding,
+                    history,
+                    onDeleteEntries = installViewModel::deleteHistoryEntries,
+                )
                 AppPage.Settings -> SettingsPage(
                     padding = padding,
                     accentColor = accentColor,
                     themeMode = themeMode,
                     advancedMode = advancedMode,
                     shizukuMode = shizukuMode,
+                    updateStatus = updateStatus,
+                    onCheckForUpdate = checkForUpdate,
                     onAccentColorChanged = onAccentColorChanged,
                     onThemeModeChanged = onThemeModeChanged,
                     onAdvancedModeChanged = onAdvancedModeChanged,
@@ -448,6 +490,9 @@ private fun OverviewPage(
     padding: PaddingValues,
     device: DeviceSnapshot,
     installState: InstallUiState,
+    updateStatus: UpdateStatus,
+    updateCardDismissed: Boolean,
+    onDismissUpdateCard: () -> Unit,
     onInstall: () -> Unit,
 ) {
     LazyColumn(
@@ -484,9 +529,125 @@ private fun OverviewPage(
                 )
             }
         }
+        if (updateStatus is UpdateStatus.Available && !updateCardDismissed) {
+            item { UpdateCard(updateStatus.info, onDismiss = onDismissUpdateCard) }
+        }
         item { InstallStatusCard(installState, onInstall) }
         item { DeviceCard(device) }
         item { HowItWorksCard() }
+    }
+}
+
+private sealed interface UpdateStatus {
+    data object Idle : UpdateStatus
+    data object Checking : UpdateStatus
+    data class Available(val info: UpdateInfo) : UpdateStatus
+    data object UpToDate : UpdateStatus
+    data object Failed : UpdateStatus
+}
+
+private fun launchUpdateDownload(
+    context: Context,
+    scope: CoroutineScope,
+    info: UpdateInfo,
+    downloadFailedMessage: String,
+    onDownloadingChange: (Boolean) -> Unit,
+    onProgress: (Float) -> Unit,
+) {
+    val apkUrl = info.apkUrl
+    if (apkUrl == null) {
+        AppUpdater.openReleasesPage(context)
+        return
+    }
+    onDownloadingChange(true)
+    scope.launch {
+        val apk = AppUpdater.downloadApk(context, apkUrl, onProgress = onProgress)
+        onDownloadingChange(false)
+        if (apk != null && AppUpdater.installApk(context, apk)) return@launch
+        Toast.makeText(context, downloadFailedMessage, Toast.LENGTH_SHORT).show()
+        AppUpdater.openReleasesPage(context)
+    }
+}
+
+@Composable
+private fun UpdateCard(info: UpdateInfo, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val downloadFailed = stringResource(R.string.updater_download_failed)
+    var downloading by remember { mutableStateOf(false) }
+    var progress by remember { mutableFloatStateOf(0f) }
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Icon(
+                    Icons.Rounded.SystemUpdate,
+                    contentDescription = null,
+                    modifier = Modifier.size(22.dp),
+                )
+                Text(
+                    text = stringResource(R.string.updater_available_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.size(24.dp),
+                ) {
+                    Icon(
+                        Icons.Rounded.Close,
+                        contentDescription = stringResource(R.string.action_close),
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+            Text(
+                text = stringResource(R.string.updater_available_body, info.versionName),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (downloading) {
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = LocalContentColor.current,
+                    trackColor = LocalContentColor.current.copy(alpha = 0.2f),
+                    drawStopIndicator = {},
+                )
+                Text(
+                    text = stringResource(R.string.updater_downloading),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = LocalContentColor.current.copy(alpha = 0.78f),
+                )
+            } else {
+                FilledTonalButton(
+                    onClick = {
+                        progress = 0f
+                        launchUpdateDownload(
+                            context = context,
+                            scope = scope,
+                            info = info,
+                            downloadFailedMessage = downloadFailed,
+                            onDownloadingChange = { downloading = it },
+                            onProgress = { p -> scope.launch { progress = p } },
+                        )
+                    },
+                ) {
+                    Text(stringResource(R.string.updater_button_download))
+                }
+            }
+        }
     }
 }
 
@@ -664,10 +825,50 @@ private fun InfoRow(icon: ImageVector, label: String, value: String) {
 private fun HistoryPage(
     padding: PaddingValues,
     history: List<InstallHistoryEntry>,
+    onDeleteEntries: (Set<String>) -> Unit,
 ) {
     var selectedHistoryId by remember { mutableStateOf<String?>(null) }
+    var selectionIds by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var pendingDeleteIds by remember { mutableStateOf<Set<String>?>(null) }
     val selectedEntry = history.firstOrNull { it.id == selectedHistoryId }
-    BackHandler(enabled = selectedEntry != null) { selectedHistoryId = null }
+    val selectableIds = history
+        .filter { it.result != InstallRunResult.Running }
+        .map { it.id }
+        .toSet()
+    val selecting = selectionIds.isNotEmpty()
+    BackHandler(enabled = selectedEntry != null || selecting) {
+        if (selecting) {
+            selectionIds = emptySet()
+        } else {
+            selectedHistoryId = null
+        }
+    }
+
+    pendingDeleteIds?.let { ids ->
+        AlertDialog(
+            onDismissRequest = { pendingDeleteIds = null },
+            icon = { Icon(Icons.Rounded.Delete, contentDescription = null) },
+            title = {
+                DialogDimAmount(0.24f)
+                Text(pluralStringResource(R.plurals.history_delete_selected_title, ids.size, ids.size))
+            },
+            text = { Text(pluralStringResource(R.plurals.history_delete_selected_body, ids.size, ids.size)) },
+            confirmButton = {
+                FilledTonalButton(onClick = {
+                    onDeleteEntries(ids)
+                    selectionIds = emptySet()
+                    pendingDeleteIds = null
+                }) {
+                    Text(stringResource(R.string.history_delete))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDeleteIds = null }) {
+                    Text(stringResource(R.string.action_cancel))
+                }
+            },
+        )
+    }
 
     AnimatedContent(
         targetState = selectedEntry,
@@ -678,7 +879,25 @@ private fun HistoryPage(
             HistoryList(
                 padding = padding,
                 history = history,
+                selectionIds = selectionIds,
+                selectableIds = selectableIds,
+                onToggleSelection = { id ->
+                    selectionIds = if (id in selectionIds) {
+                        selectionIds - id
+                    } else {
+                        selectionIds + id
+                    }
+                },
+                onSelectAll = {
+                    selectionIds = if (selectionIds.size == selectableIds.size) {
+                        emptySet()
+                    } else {
+                        selectableIds
+                    }
+                },
+                onClearSelection = { selectionIds = emptySet() },
                 onEntryClick = { selectedHistoryId = it.id },
+                onDeleteSelected = { pendingDeleteIds = selectionIds },
             )
         } else {
             HistoryDetail(
@@ -694,26 +913,96 @@ private fun HistoryPage(
 private fun HistoryList(
     padding: PaddingValues,
     history: List<InstallHistoryEntry>,
+    selectionIds: Set<String>,
+    selectableIds: Set<String>,
+    onToggleSelection: (String) -> Unit,
+    onSelectAll: () -> Unit,
+    onClearSelection: () -> Unit,
     onEntryClick: (InstallHistoryEntry) -> Unit,
+    onDeleteSelected: () -> Unit,
 ) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize().padding(padding),
-        contentPadding = PaddingValues(horizontal = 20.dp, vertical = 20.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        item {
-            Text(
-                text = stringResource(R.string.history_title),
-                style = MaterialTheme.typography.headlineLarge,
-                modifier = Modifier.padding(top = 20.dp, bottom = 14.dp),
-            )
-        }
-        if (history.isEmpty()) {
-            item { EmptyHistoryCard() }
-        } else {
-            itemsIndexed(history, key = { _, entry -> entry.id }) { _, entry ->
-                HistoryEntryCard(entry, onClick = { onEntryClick(entry) })
+    val selecting = selectionIds.isNotEmpty()
+    Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = 20.dp,
+                top = 20.dp,
+                end = 20.dp,
+                bottom = 96.dp,
+            ),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 20.dp, bottom = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier.weight(1f).height(48.dp),
+                        contentAlignment = Alignment.CenterStart,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.history_title),
+                            style = MaterialTheme.typography.headlineLarge,
+                        )
+                    }
+                    AnimatedVisibility(
+                        visible = selecting,
+                        enter = fadeIn() + scaleIn(initialScale = 0.9f),
+                        exit = fadeOut() + scaleOut(targetScale = 0.9f),
+                    ) {
+                        Row {
+                            IconButton(onClick = onSelectAll) {
+                                Icon(
+                                    Icons.Rounded.SelectAll,
+                                    contentDescription = stringResource(R.string.history_select_all),
+                                )
+                            }
+                            IconButton(onClick = onClearSelection) {
+                                Icon(
+                                    Icons.Rounded.Close,
+                                    contentDescription = stringResource(R.string.history_clear_selection),
+                                )
+                            }
+                        }
+                    }
+                }
             }
+            if (history.isEmpty()) {
+                item { EmptyHistoryCard() }
+            } else {
+                itemsIndexed(history, key = { _, entry -> entry.id }) { _, entry ->
+                    HistoryEntryCard(
+                        entry = entry,
+                        selectionMode = selecting,
+                        isSelected = entry.id in selectionIds,
+                        selectable = entry.id in selectableIds,
+                        onClick = {
+                            if (selecting) {
+                                onToggleSelection(entry.id)
+                            } else {
+                                onEntryClick(entry)
+                            }
+                        },
+                        onLongClick = {
+                            if (entry.id in selectableIds) onToggleSelection(entry.id)
+                        },
+                    )
+                }
+            }
+        }
+        AnimatedVisibility(
+            visible = selecting,
+            modifier = Modifier.align(Alignment.BottomEnd).padding(20.dp),
+            enter = fadeIn() + scaleIn(initialScale = 0.85f),
+            exit = fadeOut() + scaleOut(targetScale = 0.85f),
+        ) {
+            ExtendedFloatingActionButton(
+                onClick = onDeleteSelected,
+                icon = { Icon(Icons.Rounded.Delete, contentDescription = null) },
+                text = { Text(stringResource(R.string.history_delete_selected, selectionIds.size)) },
+            )
         }
     }
 }
@@ -746,8 +1035,16 @@ private fun EmptyHistoryCard() {
 }
 
 @Composable
-private fun HistoryEntryCard(entry: InstallHistoryEntry, onClick: () -> Unit) {
+private fun HistoryEntryCard(
+    entry: InstallHistoryEntry,
+    selectionMode: Boolean,
+    isSelected: Boolean,
+    selectable: Boolean,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+) {
     val interactionSource = remember { MutableInteractionSource() }
+    val shape = expressiveClickableCardShape(interactionSource)
     val containerColor = when (entry.result) {
         InstallRunResult.Running -> MaterialTheme.colorScheme.tertiaryContainer
         InstallRunResult.Succeeded -> MaterialTheme.colorScheme.primaryContainer
@@ -758,22 +1055,54 @@ private fun HistoryEntryCard(entry: InstallHistoryEntry, onClick: () -> Unit) {
         InstallRunResult.Succeeded -> MaterialTheme.colorScheme.onPrimaryContainer
         InstallRunResult.Failed -> MaterialTheme.colorScheme.onErrorContainer
     }
+    val borderWidth by animateDpAsState(
+        targetValue = if (selectionMode && isSelected) 2.dp else 0.dp,
+        label = "history-card-border",
+    )
     Card(
-        onClick = onClick,
-        modifier = Modifier.fillMaxWidth(),
-        shape = expressiveClickableCardShape(interactionSource),
-        interactionSource = interactionSource,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .combinedClickable(
+                interactionSource = interactionSource,
+                onClick = onClick,
+                onLongClick = onLongClick,
+            ),
+        shape = shape,
+        border = if (borderWidth > 0.dp) {
+            BorderStroke(borderWidth, MaterialTheme.colorScheme.secondary)
+        } else {
+            null
+        },
         colors = CardDefaults.cardColors(
             containerColor = containerColor,
             contentColor = contentColor,
         ),
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 15.dp),
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 15.dp)
+                .animateContentSize(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(13.dp),
         ) {
-            Icon(historyResultIcon(entry.result), contentDescription = null, modifier = Modifier.size(30.dp))
+            Crossfade(
+                targetState = selectionMode,
+                label = "history-leading",
+                modifier = Modifier.size(48.dp),
+            ) { selecting ->
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    if (selecting) {
+                        Checkbox(
+                            checked = isSelected,
+                            onCheckedChange = null,
+                            enabled = selectable,
+                        )
+                    } else {
+                        Icon(historyResultIcon(entry.result), contentDescription = null, modifier = Modifier.size(30.dp))
+                    }
+                }
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Text(historyResultLabel(entry.result), style = MaterialTheme.typography.titleMedium)
                 Text(
@@ -782,7 +1111,9 @@ private fun HistoryEntryCard(entry: InstallHistoryEntry, onClick: () -> Unit) {
                     color = contentColor.copy(alpha = 0.78f),
                 )
             }
-            Icon(Icons.Rounded.ChevronRight, contentDescription = null)
+            if (!selectionMode) {
+                Icon(Icons.Rounded.ChevronRight, contentDescription = null)
+            }
         }
     }
 }
@@ -967,6 +1298,8 @@ private fun SettingsPage(
     themeMode: AppThemeMode,
     advancedMode: Boolean,
     shizukuMode: Boolean,
+    updateStatus: UpdateStatus,
+    onCheckForUpdate: () -> Unit,
     onAccentColorChanged: (AccentColor) -> Unit,
     onThemeModeChanged: (AppThemeMode) -> Unit,
     onAdvancedModeChanged: (Boolean) -> Unit,
@@ -1123,13 +1456,105 @@ private fun SettingsPage(
         }
         item { SectionLabel(stringResource(R.string.about)) }
         item {
-            SettingsCard(
-                icon = Icons.Rounded.Info,
-                title = stringResource(R.string.about),
-                description = stringResource(R.string.about_description),
-                value = "",
-                onClick = { showAboutDialog = true },
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                UpdateSettingsCard(
+                    status = updateStatus,
+                    position = SettingsCardPosition.Top,
+                    onCheckForUpdate = onCheckForUpdate,
+                )
+                SettingsCard(
+                    icon = Icons.Rounded.Info,
+                    title = stringResource(R.string.about),
+                    description = stringResource(R.string.about_description),
+                    value = "",
+                    position = SettingsCardPosition.Bottom,
+                    onClick = { showAboutDialog = true },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpdateSettingsCard(
+    status: UpdateStatus,
+    position: SettingsCardPosition,
+    onCheckForUpdate: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val downloadFailed = stringResource(R.string.updater_download_failed)
+    var downloading by remember { mutableStateOf(false) }
+    val interactionSource = remember { MutableInteractionSource() }
+    val busy = downloading || status is UpdateStatus.Checking
+    Card(
+        onClick = {
+            when {
+                busy -> Unit
+                status is UpdateStatus.Available -> launchUpdateDownload(
+                    context = context,
+                    scope = scope,
+                    info = status.info,
+                    downloadFailedMessage = downloadFailed,
+                    onDownloadingChange = { downloading = it },
+                    onProgress = {},
+                )
+                else -> onCheckForUpdate()
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+        shape = expressiveClickableCardShape(interactionSource, position),
+        interactionSource = interactionSource,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 15.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (status is UpdateStatus.Checking) {
+                LoadingIndicator(modifier = Modifier.size(28.dp))
+            } else {
+                Icon(
+                    Icons.Rounded.SystemUpdate,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                )
+            }
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = when (status) {
+                        is UpdateStatus.Available -> stringResource(R.string.updater_available_title)
+                        else -> stringResource(R.string.updater_check)
+                    },
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                Text(
+                    text = when {
+                        downloading -> stringResource(R.string.updater_downloading)
+                        status is UpdateStatus.Checking -> stringResource(R.string.updater_checking)
+                        status is UpdateStatus.Available ->
+                            stringResource(R.string.updater_available_body_short, status.info.versionName)
+                        status == UpdateStatus.UpToDate -> stringResource(R.string.updater_up_to_date)
+                        status == UpdateStatus.Failed -> stringResource(R.string.updater_failed)
+                        else -> stringResource(R.string.updater_check)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (status is UpdateStatus.Available) {
+                Text(
+                    text = stringResource(R.string.updater_button_download),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -3,7 +3,10 @@ package dev.busung.s25uroot
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.view.HapticFeedbackConstants
+import android.view.View
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -21,12 +24,14 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -290,6 +295,7 @@ private fun RootApp(
     var compatibilityWarning by remember { mutableStateOf<CompatibilityWarning?>(null) }
     val device = remember { DeviceSnapshot.current() }
     val context = LocalContext.current
+    val view = LocalView.current
     val scope = rememberCoroutineScope()
     var updateStatus by remember { mutableStateOf<UpdateStatus>(UpdateStatus.Idle) }
     var updateCardDismissed by remember { mutableStateOf(false) }
@@ -355,7 +361,7 @@ private fun RootApp(
             },
             icon = { Icon(Icons.Rounded.Warning, contentDescription = null) },
             title = {
-                DialogDimAmount(0.24f)
+                DialogDimAmount(0.34f)
                 Text(
                     stringResource(when (warning) {
                         CompatibilityWarning.Device -> R.string.device_mismatch_title
@@ -382,6 +388,7 @@ private fun RootApp(
             confirmButton = {
                 FilledTonalButton(
                     onClick = {
+                        clickHaptic(view)
                         compatibilityWarning = when (warning) {
                             CompatibilityWarning.Device -> if (!profile.matchesKernelVersion(device)) {
                                 CompatibilityWarning.KernelVersion
@@ -401,6 +408,7 @@ private fun RootApp(
             dismissButton = {
                 TextButton(
                     onClick = {
+                        clickHaptic(view)
                         compatibilityWarning = null
                         showTargetPicker = true
                     },
@@ -416,12 +424,13 @@ private fun RootApp(
             onDismissRequest = { showInstallConfirmation = false },
             icon = { Icon(Icons.Rounded.Security, contentDescription = null) },
             title = {
-                DialogDimAmount(0.24f)
+                DialogDimAmount(0.34f)
                 Text(stringResource(R.string.install_confirm_title))
             },
             text = { Text(stringResource(R.string.install_confirm_body)) },
             confirmButton = {
                 FilledTonalButton(onClick = {
+                    clickHaptic(view)
                     showInstallConfirmation = false
                     openInstaller(selectedProfile?.profileId)
                     selectedProfile = null
@@ -430,7 +439,10 @@ private fun RootApp(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showInstallConfirmation = false }) {
+                TextButton(onClick = {
+                    clickHaptic(view)
+                    showInstallConfirmation = false
+                }) {
                     Text(stringResource(R.string.action_cancel))
                 }
             },
@@ -446,7 +458,10 @@ private fun RootApp(
                 AppPage.entries.forEach { page ->
                     NavigationBarItem(
                         selected = selectedPage == page,
-                        onClick = { selectedPage = page },
+                        onClick = {
+                            clickHaptic(view)
+                            selectedPage = page
+                        },
                         modifier = Modifier.padding(top = 4.dp),
                         icon = { Icon(page.icon, contentDescription = null) },
                         label = { Text(stringResource(page.label)) },
@@ -513,6 +528,16 @@ private fun AppVersionText(
         ),
         style = style,
         color = color,
+    )
+}
+
+private fun clickHaptic(view: View) {
+    view.performHapticFeedback(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            HapticFeedbackConstants.CONFIRM
+        } else {
+            HapticFeedbackConstants.LONG_PRESS
+        },
     )
 }
 
@@ -605,6 +630,7 @@ private fun UpdateCard(
     onDismiss: () -> Unit,
     onStartDownload: (UpdateInfo) -> Unit,
 ) {
+    val view = LocalView.current
     val info = status.info
     if (info == null) return
     Card(
@@ -634,7 +660,10 @@ private fun UpdateCard(
                     modifier = Modifier.weight(1f),
                 )
                 IconButton(
-                    onClick = onDismiss,
+                    onClick = {
+                        clickHaptic(view)
+                        onDismiss()
+                    },
                     modifier = Modifier.size(24.dp),
                 ) {
                     Icon(
@@ -664,7 +693,10 @@ private fun UpdateCard(
                     )
                 }
                 else -> {
-                    FilledTonalButton(onClick = { onStartDownload(info) }) {
+                    FilledTonalButton(onClick = {
+                        clickHaptic(view)
+                        onStartDownload(info)
+                    }) {
                         Text(stringResource(R.string.updater_button_download))
                     }
                 }
@@ -719,11 +751,13 @@ private fun HowItWorksCard() {
 @Composable
 private fun InstallStatusCard(installState: InstallUiState, onInstall: () -> Unit) {
     val context = LocalContext.current
+    val view = LocalView.current
     val interactionSource = remember { MutableInteractionSource() }
     val uriHandler = LocalUriHandler.current
     val managerInstalled = remember(installState) { isKernelSuManagerInstalled(context) }
     Card(
         onClick = {
+            clickHaptic(view)
             when {
                 installState.busy -> Unit
                 installState.phase == InstallPhase.Installed -> {
@@ -813,6 +847,7 @@ private fun InstallStatusCard(installState: InstallUiState, onInstall: () -> Uni
 
 @Composable
 private fun DeviceCard(device: DeviceSnapshot) {
+    val view = LocalView.current
     var kernelExpanded by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier.fillMaxWidth().animateContentSize(),
@@ -832,7 +867,10 @@ private fun DeviceCard(device: DeviceSnapshot) {
                 icon = Icons.Rounded.Info,
                 label = stringResource(R.string.kernel),
                 value = if (kernelExpanded) device.kernelVersionFull else device.kernelRelease,
-                onClick = { kernelExpanded = !kernelExpanded },
+                onClick = {
+                    clickHaptic(view)
+                    kernelExpanded = !kernelExpanded
+                },
             )
             InfoRow(Icons.Rounded.Security, stringResource(R.string.system_abi), "${device.abi} (${device.pageSize / 1024}K)")
         }
@@ -871,6 +909,7 @@ private fun HistoryPage(
     history: List<InstallHistoryEntry>,
     onDeleteEntries: (Set<String>) -> Unit,
 ) {
+    val view = LocalView.current
     var selectedHistoryId by remember { mutableStateOf<String?>(null) }
     var selectionIds by remember { mutableStateOf<Set<String>>(emptySet()) }
     var pendingDeleteIds by remember { mutableStateOf<Set<String>?>(null) }
@@ -893,12 +932,13 @@ private fun HistoryPage(
             onDismissRequest = { pendingDeleteIds = null },
             icon = { Icon(Icons.Rounded.Delete, contentDescription = null) },
             title = {
-                DialogDimAmount(0.24f)
+                DialogDimAmount(0.34f)
                 Text(pluralStringResource(R.plurals.history_delete_selected_title, ids.size, ids.size))
             },
             text = { Text(pluralStringResource(R.plurals.history_delete_selected_body, ids.size, ids.size)) },
             confirmButton = {
                 FilledTonalButton(onClick = {
+                    clickHaptic(view)
                     onDeleteEntries(ids)
                     selectionIds = emptySet()
                     pendingDeleteIds = null
@@ -907,7 +947,10 @@ private fun HistoryPage(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { pendingDeleteIds = null }) {
+                TextButton(onClick = {
+                    clickHaptic(view)
+                    pendingDeleteIds = null
+                }) {
                     Text(stringResource(R.string.action_cancel))
                 }
             },
@@ -965,6 +1008,7 @@ private fun HistoryList(
     onEntryClick: (InstallHistoryEntry) -> Unit,
     onDeleteSelected: () -> Unit,
 ) {
+    val view = LocalView.current
     val selecting = selectionIds.isNotEmpty()
     Box(modifier = Modifier.fillMaxSize().padding(padding)) {
         LazyColumn(
@@ -997,13 +1041,19 @@ private fun HistoryList(
                         exit = fadeOut() + scaleOut(targetScale = 0.9f),
                     ) {
                         Row {
-                            IconButton(onClick = onSelectAll) {
+                            IconButton(onClick = {
+                                clickHaptic(view)
+                                onSelectAll()
+                            }) {
                                 Icon(
                                     Icons.Rounded.SelectAll,
                                     contentDescription = stringResource(R.string.history_select_all),
                                 )
                             }
-                            IconButton(onClick = onClearSelection) {
+                            IconButton(onClick = {
+                                clickHaptic(view)
+                                onClearSelection()
+                            }) {
                                 Icon(
                                     Icons.Rounded.Close,
                                     contentDescription = stringResource(R.string.history_clear_selection),
@@ -1043,7 +1093,10 @@ private fun HistoryList(
             exit = fadeOut() + scaleOut(targetScale = 0.85f),
         ) {
             ExtendedFloatingActionButton(
-                onClick = onDeleteSelected,
+                onClick = {
+                    clickHaptic(view)
+                    onDeleteSelected()
+                },
                 icon = { Icon(Icons.Rounded.Delete, contentDescription = null) },
                 text = { Text(stringResource(R.string.history_delete_selected, selectionIds.size)) },
             )
@@ -1087,6 +1140,7 @@ private fun HistoryEntryCard(
     onClick: () -> Unit,
     onLongClick: () -> Unit,
 ) {
+    val view = LocalView.current
     val interactionSource = remember { MutableInteractionSource() }
     val shape = expressiveClickableCardShape(interactionSource)
     val containerColor = historyResultContainerColor(entry.result)
@@ -1101,8 +1155,14 @@ private fun HistoryEntryCard(
             .clip(shape)
             .combinedClickable(
                 interactionSource = interactionSource,
-                onClick = onClick,
-                onLongClick = onLongClick,
+                onClick = {
+                    clickHaptic(view)
+                    onClick()
+                },
+                onLongClick = {
+                    clickHaptic(view)
+                    onLongClick()
+                },
             ),
         shape = shape,
         border = if (borderWidth > 0.dp) {
@@ -1161,6 +1221,7 @@ private fun HistoryDetail(
     onBack: () -> Unit,
 ) {
     val context = LocalContext.current
+    val view = LocalView.current
     val exportLogLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
     ) { result ->
@@ -1177,7 +1238,10 @@ private fun HistoryDetail(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
-                IconButton(onClick = onBack) {
+                IconButton(onClick = {
+                    clickHaptic(view)
+                    onBack()
+                }) {
                     Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = stringResource(R.string.action_back))
                 }
                 Text(
@@ -1186,6 +1250,7 @@ private fun HistoryDetail(
                     modifier = Modifier.weight(1f),
                 )
                 IconButton(onClick = {
+                    clickHaptic(view)
                     exportLogLauncher.launch(
                         Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
                             addCategory(Intent.CATEGORY_OPENABLE)
@@ -1349,6 +1414,7 @@ private fun SettingsPage(
     onShizukuModeChanged: (Boolean) -> Unit,
 ) {
     val context = LocalContext.current
+    val view = LocalView.current
     val scope = rememberCoroutineScope()
     var showLanguageDialog by remember { mutableStateOf(false) }
     var showColorDialog by remember { mutableStateOf(false) }
@@ -1364,12 +1430,13 @@ private fun SettingsPage(
             onDismissRequest = { showShizukuMissingDialog = false },
             icon = { Icon(Icons.Rounded.Info, contentDescription = null) },
             title = {
-                DialogDimAmount(0.24f)
+                DialogDimAmount(0.34f)
                 Text(stringResource(R.string.shizuku_not_running_title))
             },
             text = { Text(stringResource(R.string.shizuku_not_running_body)) },
             confirmButton = {
                 FilledTonalButton(onClick = {
+                    clickHaptic(view)
                     showShizukuMissingDialog = false
                     openShizukuManager(context)
                 }) {
@@ -1377,7 +1444,10 @@ private fun SettingsPage(
                 }
             },
             dismissButton = {
-                TextButton(onClick = { showShizukuMissingDialog = false }) {
+                TextButton(onClick = {
+                    clickHaptic(view)
+                    showShizukuMissingDialog = false
+                }) {
                     Text(stringResource(R.string.action_cancel))
                 }
             },
@@ -1445,7 +1515,10 @@ private fun SettingsPage(
                     description = stringResource(R.string.material_color_description),
                     value = accentLabel(accentColor),
                     position = SettingsCardPosition.Top,
-                    onClick = { showColorDialog = true },
+                    onClick = {
+                        clickHaptic(view)
+                        showColorDialog = true
+                    },
                 )
                 SettingsCard(
                     modifier = Modifier.onGloballyPositioned { coordinates ->
@@ -1456,7 +1529,10 @@ private fun SettingsPage(
                     description = stringResource(R.string.language_description),
                     value = languageLabel(currentLanguageTag),
                     position = SettingsCardPosition.Middle,
-                    onClick = { showLanguageDialog = true },
+                    onClick = {
+                        clickHaptic(view)
+                        showLanguageDialog = true
+                    },
                 )
                 SettingsSwitchCard(
                     icon = Icons.Rounded.VerifiedUser,
@@ -1465,6 +1541,7 @@ private fun SettingsPage(
                     checked = shizukuMode,
                     position = SettingsCardPosition.Bottom,
                     onCheckedChange = { enabled ->
+                        clickHaptic(view)
                         if (!enabled) {
                             onShizukuModeChanged(false)
                         } else {
@@ -1491,7 +1568,10 @@ private fun SettingsPage(
                 title = stringResource(R.string.advanced_mode),
                 description = stringResource(R.string.advanced_mode_description),
                 checked = advancedMode,
-                onCheckedChange = onAdvancedModeChanged,
+                onCheckedChange = {
+                    clickHaptic(view)
+                    onAdvancedModeChanged(it)
+                },
             )
         }
         item { SectionLabel(stringResource(R.string.about)) }
@@ -1509,7 +1589,10 @@ private fun SettingsPage(
                     description = stringResource(R.string.about_description),
                     value = "",
                     position = SettingsCardPosition.Bottom,
-                    onClick = { showAboutDialog = true },
+                    onClick = {
+                        clickHaptic(view)
+                        showAboutDialog = true
+                    },
                 )
             }
         }
@@ -1524,9 +1607,11 @@ private fun UpdateSettingsCard(
     onStartDownload: (UpdateInfo) -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val view = LocalView.current
     val busy = status.busy
     Card(
         onClick = {
+            clickHaptic(view)
             when {
                 busy -> Unit
                 status is UpdateStatus.Available -> onStartDownload(status.info)
@@ -1605,6 +1690,7 @@ private fun TargetSelectionSheet(
 ) {
     var showOnlyMyDevice by remember { mutableStateOf(true) }
     var selectedProfileId by remember { mutableStateOf<String?>(null) }
+    val view = LocalView.current
     val visibleProfiles = remember(catalog.profiles, showOnlyMyDevice, device) {
         if (showOnlyMyDevice) {
             catalog.profiles.filter { it.matches(device) }
@@ -1640,6 +1726,7 @@ private fun TargetSelectionSheet(
                         value = showOnlyMyDevice,
                         role = Role.Checkbox,
                         onValueChange = { enabled ->
+                            clickHaptic(view)
                             showOnlyMyDevice = enabled
                             if (enabled && selectedProfile?.matches(device) == false) {
                                 selectedProfileId = null
@@ -1706,7 +1793,10 @@ private fun TargetSelectionSheet(
                                     .selectable(
                                         selected = selected,
                                         role = Role.RadioButton,
-                                        onClick = { selectedProfileId = profile.profileId },
+                                        onClick = {
+                                            clickHaptic(view)
+                                            selectedProfileId = profile.profileId
+                                        },
                                     )
                                     .padding(horizontal = 14.dp, vertical = 12.dp),
                                 verticalAlignment = Alignment.CenterVertically,
@@ -1735,11 +1825,17 @@ private fun TargetSelectionSheet(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                TextButton(onClick = onDismiss, modifier = Modifier.weight(1f)) {
+                TextButton(onClick = {
+                    clickHaptic(view)
+                    onDismiss()
+                }, modifier = Modifier.weight(1f)) {
                     Text(stringResource(R.string.action_cancel))
                 }
                 Button(
-                    onClick = { selectedProfile?.let(onNext) },
+                    onClick = {
+                        clickHaptic(view)
+                        selectedProfile?.let(onNext)
+                    },
                     enabled = selectedProfile != null,
                     modifier = Modifier.weight(1f),
                 ) {
@@ -1779,8 +1875,12 @@ private fun SettingsCard(
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val view = LocalView.current
     Card(
-        onClick = onClick,
+        onClick = {
+            clickHaptic(view)
+            onClick()
+        },
         modifier = modifier.fillMaxWidth(),
         shape = expressiveClickableCardShape(interactionSource, position),
         interactionSource = interactionSource,
@@ -1824,8 +1924,12 @@ private fun SettingsSwitchCard(
     onCheckedChange: (Boolean) -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    val view = LocalView.current
     Card(
-        onClick = { onCheckedChange(!checked) },
+        onClick = {
+            clickHaptic(view)
+            onCheckedChange(!checked)
+        },
         modifier = Modifier.fillMaxWidth(),
         shape = expressiveClickableCardShape(interactionSource, position),
         interactionSource = interactionSource,
@@ -1857,6 +1961,7 @@ private fun ThemeModeSelector(
     themeMode: AppThemeMode,
     onThemeModeChanged: (AppThemeMode) -> Unit,
 ) {
+    val view = LocalView.current
     val themeModes = AppThemeMode.entries
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -1865,7 +1970,10 @@ private fun ThemeModeSelector(
         themeModes.forEachIndexed { index, mode ->
             ToggleButton(
                 checked = themeMode == mode,
-                onCheckedChange = { onThemeModeChanged(mode) },
+                onCheckedChange = {
+                    clickHaptic(view)
+                    onThemeModeChanged(mode)
+                },
                 modifier = Modifier.weight(1f).semantics { role = Role.RadioButton },
                 colors = ToggleButtonDefaults.toggleButtonColors(
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
@@ -1895,10 +2003,11 @@ private fun ThemeModeSelector(
 @Composable
 private fun AboutDialog(onDismiss: () -> Unit) {
     val uriHandler = LocalUriHandler.current
+    val view = LocalView.current
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
-            DialogDimAmount(0.24f)
+            DialogDimAmount(0.34f)
             Text(stringResource(R.string.about_title))
         },
         text = {
@@ -1910,7 +2019,10 @@ private fun AboutDialog(onDismiss: () -> Unit) {
                 )
                 HorizontalDivider()
                 Surface(
-                    onClick = { uriHandler.openUri(KERNEL_SU_HOME_URL) },
+                    onClick = {
+                        clickHaptic(view)
+                        uriHandler.openUri(KERNEL_SU_HOME_URL)
+                    },
                     color = Color.Transparent,
                     shape = MaterialTheme.shapes.medium,
                 ) {
@@ -1935,7 +2047,10 @@ private fun AboutDialog(onDismiss: () -> Unit) {
                     }
                 }
                 Surface(
-                    onClick = { uriHandler.openUri(ROOT_MY_GALAXY_URL) },
+                    onClick = {
+                        clickHaptic(view)
+                        uriHandler.openUri(ROOT_MY_GALAXY_URL)
+                    },
                     color = Color.Transparent,
                     shape = MaterialTheme.shapes.medium,
                 ) {
@@ -1962,7 +2077,10 @@ private fun AboutDialog(onDismiss: () -> Unit) {
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(onClick = {
+                clickHaptic(view)
+                onDismiss()
+            }) {
                 Text(stringResource(R.string.action_close))
             }
         },
@@ -2020,6 +2138,12 @@ private fun SideChoiceMenu(
     var visible by remember { mutableStateOf(false) }
     var closing by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
+    val view = LocalView.current
+    val scrimAlpha by animateFloatAsState(
+        targetValue = if (visible) 0.34f else 0f,
+        animationSpec = tween(durationMillis = if (visible) 160 else 180),
+        label = "menu-scrim",
+    )
 
     fun closeMenu(afterAnimation: () -> Unit) {
         if (closing) return
@@ -2053,6 +2177,7 @@ private fun SideChoiceMenu(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .background(Color.Black.copy(alpha = scrimAlpha))
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
@@ -2106,6 +2231,7 @@ private fun SideChoiceMenu(
                             val selected = index == selectedIndex
                             Surface(
                                 onClick = {
+                                    clickHaptic(view)
                                     closeMenu { onSelected(index) }
                                 },
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -149,6 +149,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        window.isNavigationBarContrastEnforced = false
         accentColor = AppPreferences.accentColor(this)
         themeMode = AppPreferences.themeMode(this)
         advancedMode = AppPreferences.advancedMode(this)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,26 @@
     <string name="kernelsu_card_description">Une solution root basée sur le noyau pour Android</string>
     <string name="history_shizuku_used">Shizuku utilisé</string>
     <string name="history_shizuku_not_used">Shizuku non utilisé</string>
+    <string name="updater_available_title">Une mise à jour est disponible</string>
+    <string name="updater_available_body">La version %1$s est disponible</string>
+    <string name="updater_button_download">Télécharger et installer</string>
+    <string name="updater_downloading">Téléchargement…</string>
+    <string name="updater_download_failed">Échec du téléchargement</string>
+    <string name="updater_check">Vérifier les mises à jour</string>
+    <string name="updater_checking">Vérification des mises à jour…</string>
+    <string name="updater_up_to_date">Vous êtes à jour</string>
+    <string name="updater_failed">Échec de la vérification des mises à jour</string>
+    <string name="updater_available_body_short">%1$s est disponible</string>
+    <string name="history_select_all">Tout sélectionner</string>
+    <string name="history_clear_selection">Effacer la sélection</string>
+    <string name="history_delete_selected">Supprimer (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Supprimer cette exécution ?</item>
+        <item quantity="other">Supprimer %1$d exécutions ?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Cette exécution et son journal seront définitivement supprimés.</item>
+        <item quantity="other">Ces exécutions et leurs journaux seront définitivement supprimés.</item>
+    </plurals>
+    <string name="history_delete">Supprimer</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -17,7 +17,7 @@
     <string name="install_tap_start">Appuyez pour installer KernelSU</string>
     <string name="device">Appareil</string>
     <string name="firmware">Firmware</string>
-    <string name="system">Système</string>
+    <string name="system">Système</string><string name="kernel">Noyau</string>
     <string name="system_abi">ABI système</string>
     <string name="settings">Paramètres</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,7 +4,7 @@
     <string name="install_confirm_title">KernelSUをインストールしますか？</string><string name="install_confirm_body">対応プロファイルを確認し、exploitとKernelSU payloadをGitHubから取得して実行します。</string>
     <string name="action_confirm">確認</string><string name="action_cancel">キャンセル</string><string name="action_close">閉じる</string><string name="action_retry">再試行</string><string name="action_done">完了</string><string name="action_back">戻る</string>
     <string name="install_tap_manager">タップしてKernelSU Managerをインストール</string><string name="install_tap_retry">タップして再試行</string><string name="install_tap_start">タップしてKernelSUをインストール</string>
-    <string name="device">デバイス</string><string name="firmware">ファームウェア</string><string name="system">システム</string><string name="system_abi">システムABI</string>
+    <string name="device">デバイス</string><string name="firmware">ファームウェア</string><string name="system">システム</string><string name="kernel">カーネル</string><string name="system_abi">システムABI</string>
     <string name="settings">設定</string><string name="version_format">%1$s (%2$d)</string><string name="language">言語</string><string name="language_description">アプリの表示言語を選択</string><string name="appearance">外観</string><string name="theme_system">システム</string><string name="theme_light">ライト</string><string name="theme_dark">ダーク</string><string name="material_color">テーマ</string><string name="material_color_description">見た目を変更</string>
     <string name="language_system">システム設定に従う</string>
     <string name="color_dynamic">システム動的カラー</string><string name="color_blue">ブルー</string><string name="color_violet">バイオレット</string><string name="color_green">グリーン</string><string name="color_orange">オレンジ</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -39,4 +39,26 @@
     <string name="kernelsu_card_description">Android向けカーネルベースのrootソリューション</string>
     <string name="history_shizuku_used">Shizukuを使用</string>
     <string name="history_shizuku_not_used">Shizuku未使用</string>
+    <string name="updater_available_title">アップデートがあります</string>
+    <string name="updater_available_body">バージョン %1$s が利用可能です</string>
+    <string name="updater_button_download">ダウンロードしてインストール</string>
+    <string name="updater_downloading">ダウンロード中…</string>
+    <string name="updater_download_failed">ダウンロードに失敗しました</string>
+    <string name="updater_check">アップデートを確認</string>
+    <string name="updater_checking">アップデートを確認中…</string>
+    <string name="updater_up_to_date">最新バージョンです</string>
+    <string name="updater_failed">アップデートの確認に失敗しました</string>
+    <string name="updater_available_body_short">%1$s が利用可能です</string>
+    <string name="history_select_all">すべて選択</string>
+    <string name="history_clear_selection">選択を解除</string>
+    <string name="history_delete_selected">削除 (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">この実行を削除しますか？</item>
+        <item quantity="other">%1$d件の実行を削除しますか？</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">この実行とログは完全に削除されます。</item>
+        <item quantity="other">これらの実行とログは完全に削除されます。</item>
+    </plurals>
+    <string name="history_delete">削除</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -5,7 +5,7 @@
     <string name="install_confirm_title">KernelSU를 설치할까요?</string><string name="install_confirm_body">지원 프로필을 확인한 뒤 exploit과 KernelSU payload를 GitHub에서 받아 실행합니다.</string>
     <string name="action_confirm">확인</string><string name="action_cancel">취소</string><string name="action_close">닫기</string><string name="action_retry">다시 시도</string><string name="action_done">완료</string><string name="action_back">뒤로</string>
     <string name="install_tap_manager">클릭해서 KSU 매니저 설치하기</string><string name="install_tap_retry">눌러서 다시 시도</string><string name="install_tap_start">눌러서 KernelSU 설치</string>
-    <string name="device">기기</string><string name="firmware">펌웨어</string><string name="system">시스템</string><string name="system_abi">시스템 ABI</string>
+    <string name="device">기기</string><string name="firmware">펌웨어</string><string name="system">시스템</string><string name="kernel">커널</string><string name="system_abi">시스템 ABI</string>
     <string name="settings">설정</string><string name="version_format">%1$s (%2$d)</string><string name="language">언어</string><string name="language_description">앱에서 사용할 언어를 선택합니다</string><string name="appearance">화면</string><string name="theme_system">시스템</string><string name="theme_light">라이트</string><string name="theme_dark">다크</string><string name="material_color">테마</string><string name="material_color_description">모양 변경</string>
     <string name="language_system">시스템 설정 따름</string>
     <string name="color_dynamic">시스템 동적 색상</string><string name="color_blue">파랑</string><string name="color_violet">보라</string><string name="color_green">초록</string><string name="color_orange">주황</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -40,4 +40,26 @@
     <string name="kernelsu_card_description">Android용 커널 기반 루트 솔루션</string>
     <string name="history_shizuku_used">Shizuku 사용됨</string>
     <string name="history_shizuku_not_used">Shizuku 사용 안 함</string>
+    <string name="updater_available_title">업데이트가 있습니다</string>
+    <string name="updater_available_body">버전 %1$s를 사용할 수 있습니다</string>
+    <string name="updater_button_download">다운로드 및 설치</string>
+    <string name="updater_downloading">다운로드 중…</string>
+    <string name="updater_download_failed">다운로드 실패</string>
+    <string name="updater_check">업데이트 확인</string>
+    <string name="updater_checking">업데이트 확인 중…</string>
+    <string name="updater_up_to_date">최신 버전입니다</string>
+    <string name="updater_failed">업데이트 확인 실패</string>
+    <string name="updater_available_body_short">%1$s 사용 가능</string>
+    <string name="history_select_all">모두 선택</string>
+    <string name="history_clear_selection">선택 해제</string>
+    <string name="history_delete_selected">삭제 (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">이 실행을 삭제할까요?</item>
+        <item quantity="other">%1$d개 실행을 삭제할까요?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">이 실행과 로그가 영구적으로 삭제됩니다.</item>
+        <item quantity="other">이 실행들과 로그가 영구적으로 삭제됩니다.</item>
+    </plurals>
+    <string name="history_delete">삭제</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -127,4 +127,46 @@
     <string name="device_mismatch_body">Esse celular é o %1$s, mas o payload que você selecionou suporta o %2$s. Rodar ele pode crashar ou danificar o dispositivo.</string>
     <string name="kernel_version_mismatch_title">Versão de kernel incompatível</string>
     <string name="kernel_version_mismatch_body">Esse celular usa o kernel %1$s, mas o payload que você selecionou suporta o %2$s. Os offsets podem ser incompatíveis.</string>
+    <string name="shizuku_mode">Usar Shizuku</string>
+    <string name="shizuku_mode_description">Usar o Shizuku para executar o payload. Isso pode melhorar a confiabilidade.</string>
+    <string name="shizuku_not_running_title">Shizuku não está em execução</string>
+    <string name="shizuku_not_running_body">Inicie o Shizuku com adb ou root primeiro.</string>
+    <string name="action_download_shizuku">Baixar o Shizuku</string>
+    <string name="error_shizuku_unavailable">Shizuku não está em execução. Inicie o Shizuku com adb ou root primeiro.</string>
+    <string name="error_shizuku_permission">Permissão do Shizuku não concedida</string>
+    <string name="error_shizuku_stage">Não foi possível preparar %1$s pelo Shizuku: %2$s</string>
+    <string name="log_shizuku_prepare">[*] Preparando a execução do Shizuku</string>
+    <string name="log_shizuku_permission">[+] Permissão do Shizuku concedida</string>
+    <string name="about">Sobre</string>
+    <string name="about_title">Sobre o Root My Galaxy</string>
+    <string name="about_description">Sobre o Root My Galaxy</string>
+    <string name="about_body">Instalador de um toque que usa uma exploração de kernel para enraizar dispositivos Samsung Galaxy compatíveis.</string>
+    <string name="kernelsu_card_description">Solução de root baseada em kernel para Android</string>
+    <string name="history_shizuku_used">Shizuku: usado</string>
+    <string name="history_shizuku_not_used">Shizuku: não usado</string>
+    <string name="export_log">Exportar log</string>
+    <string name="export_log_saved">Log salvo</string>
+    <string name="export_log_failed">Falha ao salvar o log</string>
+    <string name="updater_available_title">Uma atualização está disponível</string>
+    <string name="updater_available_body">A versão %1$s está disponível</string>
+    <string name="updater_available_body_short">%1$s está disponível</string>
+    <string name="updater_button_download">Baixar e instalar</string>
+    <string name="updater_downloading">Baixando…</string>
+    <string name="updater_download_failed">Falha no download</string>
+    <string name="updater_check">Verificar atualizações</string>
+    <string name="updater_checking">Verificando atualizações…</string>
+    <string name="updater_up_to_date">Você está atualizado</string>
+    <string name="updater_failed">Falha ao verificar atualizações</string>
+    <string name="history_select_all">Selecionar tudo</string>
+    <string name="history_clear_selection">Limpar seleção</string>
+    <string name="history_delete_selected">Excluir (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Excluir esta execução?</item>
+        <item quantity="other">Excluir %1$d execuções?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Esta execução e seu log serão removidos permanentemente.</item>
+        <item quantity="other">Estas execuções e seus logs serão removidos permanentemente.</item>
+    </plurals>
+    <string name="history_delete">Excluir</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -17,7 +17,7 @@
     <string name="install_tap_start">Toque para instalar o KernelSU</string>
     <string name="device">Dispositivo</string>
     <string name="firmware">Firmware</string>
-    <string name="system">Sistema</string>
+    <string name="system">Sistema</string><string name="kernel">Kernel</string>
     <string name="system_abi">ABI do Sistema</string>
     <string name="settings">Configurações</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -151,4 +151,26 @@
     <string name="kernelsu_card_description">Ядровое root-решение для Android</string>
     <string name="history_shizuku_used">Shizuku использовался</string>
     <string name="history_shizuku_not_used">Shizuku не использовался</string>
+    <string name="updater_available_title">Доступно обновление</string>
+    <string name="updater_available_body">Доступна версия %1$s</string>
+    <string name="updater_button_download">Скачать и установить</string>
+    <string name="updater_downloading">Загрузка…</string>
+    <string name="updater_download_failed">Не удалось загрузить</string>
+    <string name="updater_check">Проверить обновления</string>
+    <string name="updater_checking">Проверка обновлений…</string>
+    <string name="updater_up_to_date">У вас последняя версия</string>
+    <string name="updater_failed">Не удалось проверить обновления</string>
+    <string name="updater_available_body_short">%1$s доступна</string>
+    <string name="history_select_all">Выбрать все</string>
+    <string name="history_clear_selection">Снять выделение</string>
+    <string name="history_delete_selected">Удалить (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Удалить этот запуск?</item>
+        <item quantity="other">Удалить %1$d запусков?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Этот запуск и его журнал будут удалены навсегда.</item>
+        <item quantity="other">Эти запуски и их журналы будут удалены навсегда.</item>
+    </plurals>
+    <string name="history_delete">Удалить</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -18,7 +18,7 @@
     <string name="install_tap_start">Нажмите, чтобы установить KernelSU</string>
     <string name="device">Устройство</string>
     <string name="firmware">Прошивка</string>
-    <string name="system">Система</string>
+    <string name="system">Система</string><string name="kernel">Ядро</string>
     <string name="system_abi">ABI системы</string>
     <string name="settings">Настройки</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -17,7 +17,7 @@
     <string name="install_tap_start">KernelSU yüklemek için dokunun</string>
     <string name="device">Cihaz</string>
     <string name="firmware">Yazılım Sürümü</string>
-    <string name="system">Sistem</string>
+    <string name="system">Sistem</string><string name="kernel">Çekirdek</string>
     <string name="system_abi">Sistem ABI</string>
     <string name="settings">Ayarlar</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -142,4 +142,26 @@
     <string name="kernelsu_card_description">Android için çekirdek tabanlı root çözümü</string>
     <string name="history_shizuku_used">Shizuku kullanıldı</string>
     <string name="history_shizuku_not_used">Shizuku kullanılmadı</string>
+    <string name="updater_available_title">Bir güncelleme mevcut</string>
+    <string name="updater_available_body">%1$s sürümü mevcut</string>
+    <string name="updater_button_download">İndir ve Kur</string>
+    <string name="updater_downloading">İndiriliyor…</string>
+    <string name="updater_download_failed">İndirme başarısız</string>
+    <string name="updater_check">Güncellemeleri kontrol et</string>
+    <string name="updater_checking">Güncellemeler kontrol ediliyor…</string>
+    <string name="updater_up_to_date">Güncel sürümdesiniz</string>
+    <string name="updater_failed">Güncelleme kontrol edilemedi</string>
+    <string name="updater_available_body_short">%1$s mevcut</string>
+    <string name="history_select_all">Tümünü seç</string>
+    <string name="history_clear_selection">Seçimi temizle</string>
+    <string name="history_delete_selected">Sil (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Bu kayıt silinsin mi?</item>
+        <item quantity="other">%1$d kayıt silinsin mi?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Bu kayıt ve günlüğü kalıcı olarak silinecek.</item>
+        <item quantity="other">Bu kayıtlar ve günlükleri kalıcı olarak silinecek.</item>
+    </plurals>
+    <string name="history_delete">Sil</string>
 </resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -153,4 +153,26 @@
     <string name="device_mismatch_body">Sizning telefoningiz %1$s, biroq tanlangan paket %2$s\'ni qo\'llab-quvvatlaydi. Uni ishga tushirish qurilmaning qotib qolishi yoki zararlanishiga olib kelishi mumkin.</string>
     <string name="kernel_version_mismatch_title">Yadro versiyasi mos kelmadi</string>
     <string name="kernel_version_mismatch_body">Sizning telefoningiz %1$s yadrosidan foydalanadi, lekin tanlangan paket %2$s\'ni qo\'llab-quvvatlaydi. Ofsetlar mos kelmasligi ehtimoli bor.</string>
+    <string name="updater_available_title">Yangilanish mavjud</string>
+    <string name="updater_available_body">%1$s versiyasi mavjud</string>
+    <string name="updater_available_body_short">%1$s mavjud</string>
+    <string name="updater_button_download">Yuklab olish va o\'rnatish</string>
+    <string name="updater_downloading">Yuklab olinmoqda…</string>
+    <string name="updater_download_failed">Yuklab olish muvaffaqiyatsiz tugadi</string>
+    <string name="updater_check">Yangilanishlarni tekshirish</string>
+    <string name="updater_checking">Yangilanishlar tekshirilmoqda…</string>
+    <string name="updater_up_to_date">Sizda eng so\'nggi versiya</string>
+    <string name="updater_failed">Yangilanishlarni tekshirib bo\'lmadi</string>
+    <string name="history_select_all">Hammasini tanlash</string>
+    <string name="history_clear_selection">Tanlovni bekor qilish</string>
+    <string name="history_delete_selected">O\'chirish (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Ushbu jarayon o\'chirilsinmi?</item>
+        <item quantity="other">%1$d ta jarayon o\'chirilsinmi?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Bu jarayon va uning jurnali butunlay o\'chiriladi.</item>
+        <item quantity="other">Bu jarayonlar va ularning jurnallari butunlay o\'chiriladi.</item>
+    </plurals>
+    <string name="history_delete">O\'chirish</string>
 </resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -21,7 +21,7 @@
     <string name="kernelsu_card_title">KernelSU</string>
     <string name="kernelsu_card_description">Android uchun karnel-asoslangan rootlash</string>
     <string name="firmware">Proshivka</string>
-    <string name="system">Tizim</string>
+    <string name="system">Tizim</string><string name="kernel">Yadro</string>
     <string name="system_abi">Tizim ABI\'si</string>
     <string name="settings">Sozlamalar</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -17,7 +17,7 @@
     <string name="install_tap_start">Chạm để cài đặt KernelSU</string>
     <string name="device">Thiết bị</string>
     <string name="firmware">Firmware</string>
-    <string name="system">Hệ thống</string>
+    <string name="system">Hệ thống</string><string name="kernel">Kernel</string>
     <string name="system_abi">ABI hệ thống</string>
     <string name="settings">Cài đặt</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -142,4 +142,26 @@
     <string name="kernelsu_card_description">Giải pháp root dựa trên kernel cho Android</string>
     <string name="history_shizuku_used">Đã dùng Shizuku</string>
     <string name="history_shizuku_not_used">Không dùng Shizuku</string>
+    <string name="updater_available_title">Có bản cập nhật mới</string>
+    <string name="updater_available_body">Phiên bản %1$s hiện có sẵn</string>
+    <string name="updater_button_download">Tải xuống và cài đặt</string>
+    <string name="updater_downloading">Đang tải xuống…</string>
+    <string name="updater_download_failed">Tải xuống thất bại</string>
+    <string name="updater_check">Kiểm tra cập nhật</string>
+    <string name="updater_checking">Đang kiểm tra cập nhật…</string>
+    <string name="updater_up_to_date">Bạn đang dùng bản mới nhất</string>
+    <string name="updater_failed">Không thể kiểm tra cập nhật</string>
+    <string name="updater_available_body_short">%1$s có sẵn</string>
+    <string name="history_select_all">Chọn tất cả</string>
+    <string name="history_clear_selection">Bỏ chọn</string>
+    <string name="history_delete_selected">Xóa (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Xóa lần chạy này?</item>
+        <item quantity="other">Xóa %1$d lần chạy?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">Lần chạy này và nhật ký của nó sẽ bị xóa vĩnh viễn.</item>
+        <item quantity="other">Các lần chạy này và nhật ký của chúng sẽ bị xóa vĩnh viễn.</item>
+    </plurals>
+    <string name="history_delete">Xóa</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -39,4 +39,26 @@
     <string name="kernelsu_card_description">基于内核的 Android Root 方案</string>
     <string name="history_shizuku_used">已使用 Shizuku</string>
     <string name="history_shizuku_not_used">未使用 Shizuku</string>
+    <string name="updater_available_title">有可用更新</string>
+    <string name="updater_available_body">新版本 %1$s 可用</string>
+    <string name="updater_button_download">下载并安装</string>
+    <string name="updater_downloading">下载中…</string>
+    <string name="updater_download_failed">下载失败</string>
+    <string name="updater_check">检查更新</string>
+    <string name="updater_checking">正在检查更新…</string>
+    <string name="updater_up_to_date">已是最新版本</string>
+    <string name="updater_failed">检查更新失败</string>
+    <string name="updater_available_body_short">%1$s 可用</string>
+    <string name="history_select_all">全选</string>
+    <string name="history_clear_selection">清除选择</string>
+    <string name="history_delete_selected">删除 (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">删除此运行记录？</item>
+        <item quantity="other">删除 %1$d 次运行？</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">此运行记录及其日志将被永久删除。</item>
+        <item quantity="other">这些运行记录及其日志将被永久删除。</item>
+    </plurals>
+    <string name="history_delete">删除</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -4,7 +4,7 @@
     <string name="install_confirm_title">安装 KernelSU？</string><string name="install_confirm_body">应用将验证支持配置，然后从 GitHub 下载并运行 exploit 与 KernelSU payload。</string>
     <string name="action_confirm">确认</string><string name="action_cancel">取消</string><string name="action_close">关闭</string><string name="action_retry">重试</string><string name="action_done">完成</string><string name="action_back">返回</string>
     <string name="install_tap_manager">点击安装 KernelSU Manager</string><string name="install_tap_retry">点击重试</string><string name="install_tap_start">点击安装 KernelSU</string>
-    <string name="device">设备</string><string name="firmware">固件</string><string name="system">系统</string><string name="system_abi">系统 ABI</string>
+    <string name="device">设备</string><string name="firmware">固件</string><string name="system">系统</string><string name="kernel">内核</string><string name="system_abi">系统 ABI</string>
     <string name="settings">设置</string><string name="version_format">%1$s (%2$d)</string><string name="language">语言</string><string name="language_description">选择应用语言</string><string name="appearance">外观</string><string name="theme_system">系统</string><string name="theme_light">浅色</string><string name="theme_dark">深色</string><string name="material_color">主题</string><string name="material_color_description">更改外观</string>
     <string name="language_system">跟随系统</string>
     <string name="color_dynamic">系统动态颜色</string><string name="color_blue">蓝色</string><string name="color_violet">紫色</string><string name="color_green">绿色</string><string name="color_orange">橙色</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -162,4 +162,26 @@
     <string name="kernelsu_card_description">以核心為基礎的 Android Root 解決方案</string>
     <string name="history_shizuku_used">已使用 Shizuku</string>
     <string name="history_shizuku_not_used">未使用 Shizuku</string>
+    <string name="updater_available_title">有可用更新</string>
+    <string name="updater_available_body">新版本 %1$s 可用</string>
+    <string name="updater_button_download">下載並安裝</string>
+    <string name="updater_downloading">下載中…</string>
+    <string name="updater_download_failed">下載失敗</string>
+    <string name="updater_check">檢查更新</string>
+    <string name="updater_checking">正在檢查更新…</string>
+    <string name="updater_up_to_date">已是最新版本</string>
+    <string name="updater_failed">檢查更新失敗</string>
+    <string name="updater_available_body_short">%1$s 可用</string>
+    <string name="history_select_all">全選</string>
+    <string name="history_clear_selection">清除選擇</string>
+    <string name="history_delete_selected">刪除 (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">刪除此執行紀錄？</item>
+        <item quantity="other">刪除 %1$d 次執行？</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">此執行紀錄及其日誌將被永久刪除。</item>
+        <item quantity="other">這些執行紀錄及其日誌將被永久刪除。</item>
+    </plurals>
+    <string name="history_delete">刪除</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,7 +21,7 @@
 
     <string name="device">裝置</string>
     <string name="firmware">韌體</string>
-    <string name="system">系統</string>
+    <string name="system">系統</string><string name="kernel">核心</string>
     <string name="system_abi">系統 ABI</string>
 
     <string name="settings">設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="kernelsu_card_description">A kernel-based root solution for Android</string>
     <string name="firmware">Firmware</string>
     <string name="system">System</string>
+    <string name="kernel">Kernel</string>
     <string name="system_abi">System ABI</string>
     <string name="settings">Settings</string>
     <string name="version_format">%1$s (%2$d)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,4 +153,26 @@
     <string name="device_mismatch_body">This phone is %1$s, but the selected payload supports %2$s. Running it may crash or damage the device.</string>
     <string name="kernel_version_mismatch_title">Kernel version mismatch</string>
     <string name="kernel_version_mismatch_body">This phone uses kernel %1$s, but the selected payload supports %2$s. Offsets may be incompatible.</string>
+    <string name="updater_available_title">An update is available</string>
+    <string name="updater_available_body">Version %1$s is now available</string>
+    <string name="updater_available_body_short">%1$s is available</string>
+    <string name="updater_button_download">Download &amp; Install</string>
+    <string name="updater_downloading">Downloading…</string>
+    <string name="updater_download_failed">Download failed</string>
+    <string name="updater_check">Check for updates</string>
+    <string name="updater_checking">Checking for updates…</string>
+    <string name="updater_up_to_date">You\'re up to date</string>
+    <string name="updater_failed">Failed to check for updates</string>
+    <string name="history_delete">Delete</string>
+    <string name="history_select_all">Select all</string>
+    <string name="history_clear_selection">Clear selection</string>
+    <string name="history_delete_selected">Delete (%1$d)</string>
+    <plurals name="history_delete_selected_title">
+        <item quantity="one">Delete this run?</item>
+        <item quantity="other">Delete %1$d runs?</item>
+    </plurals>
+    <plurals name="history_delete_selected_body">
+        <item quantity="one">This run and its log will be permanently removed.</item>
+        <item quantity="other">These runs and their logs will be permanently removed.</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="updates" path="updates/" />
+</paths>


### PR DESCRIPTION
- Add app updater with automatic version check on launch, dismissible
  update card on the home screen, and a manual check in Settings that
  downloads and installs the latest release APK from GitHub
- Add long-press multi-select to the run history with batch deletion
  and proper singular/plural confirmation strings
  
  Added @bocajthomas 's nav bar commit here too. Sorry.