### PR TITLE
Add support for SM-S938B kernel 6.6.30 via custom payload repo

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -137,10 +137,10 @@ class PayloadRepository(private val context: Context) {
 
     companion object {
         private const val COMMIT_API_URL =
-            "https://api.github.com/repos/BuSung-dev/Root-My-Galaxy-Payloads/git/ref/heads/main"
+            "https://api.github.com/repos/QBANIN/Root-My-Galaxy-Payloads/git/ref/heads/add-pa3q-S938BXXS5AYG2"
         private const val RAW_REPOSITORY =
-            "https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads"
-        private const val MUTABLE_RAW_PREFIX = "$RAW_REPOSITORY/main/"
+            "https://raw.githubusercontent.com/QBANIN/Root-My-Galaxy-Payloads"
+        private const val MUTABLE_RAW_PREFIX = "$RAW_REPOSITORY/add-pa3q-S938BXXS5AYG2/"
         private const val MAX_COMMIT_RESPONSE_BYTES = 16 * 1024
         private const val MAX_MANIFEST_BYTES = 256 * 1024
     }


### PR DESCRIPTION
## Summary

Use QBANIN fork of Root-My-Galaxy-Payloads which includes custom profile for **SM-S938B (Galaxy S25 Ultra)** with **kernel 6.6.30** (firmware S938BXXS5AYG2).

## Changes

- `PayloadRepository.kt`: Updated repository URLs to use QBANIN/Root-My-Galaxy-Payloads branch `add-pa3q-S938BXXS5AYG2`

## Payload PR

Corresponding payload PR: https://github.com/BuSung-dev/Root-My-Galaxy-Payloads/pull/158