### PR TITLE
Enforce exact firmware payload matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
         with:
-          packages: 'platform-tools platforms;android-37 cmake;3.22.1'
+          packages: 'platform-tools platforms;android-36 cmake;3.22.1'
           accept-android-sdk-licenses: true
 
       - name: Setup NDK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - '**'
+  pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -28,7 +29,7 @@ jobs:
       - name: Set up Android SDK
         uses: android-actions/setup-android@v4
         with:
-          packages: 'platform-tools platforms;android-35 cmake;3.22.1'
+          packages: 'platform-tools platforms;android-37 cmake;3.22.1'
           accept-android-sdk-licenses: true
 
       - name: Setup NDK
@@ -38,6 +39,9 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --no-daemon
 
       - name: Build debug APK
         run: ./gradlew assembleDebug --no-daemon

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "dev.busung.s25uroot"
-    compileSdk = 37
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "dev.busung.s25uroot"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,14 +60,14 @@ kotlin {
 }
 
 dependencies {
-    implementation(platform("androidx.compose:compose-bom:2026.05.01"))
-    implementation("androidx.activity:activity-compose:1.13.0")
+    implementation(platform("androidx.compose:compose-bom:2026.04.01"))
+    implementation("androidx.activity:activity-compose:1.12.4")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.10.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3:1.5.0-alpha24")
+    implementation("androidx.compose.material3:material3:1.5.0-alpha18")
     implementation("androidx.compose.material:material-icons-extended")
     implementation("com.materialkolor:material-kolor:4.1.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.11.0")
@@ -76,6 +76,7 @@ dependencies {
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20250517")
     androidTestImplementation("androidx.test:core-ktx:1.7.0")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test:runner:1.7.0")

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -150,10 +150,19 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                     appendLog(app.getString(R.string.log_shizuku_permission))
                 }
                 setPhase(InstallPhase.Checking, app.getString(R.string.status_checking_github))
+                val snapshot = DeviceSnapshot.current()
                 val profile = if (profileId == null) {
-                    repository.resolveTarget(DeviceSnapshot.current())
+                    repository.resolveTarget(snapshot)
                 } else {
                     repository.resolveTarget(profileId)
+                }
+                require(profile.matchesExactBuild(snapshot)) {
+                    app.getString(
+                        R.string.error_exact_build_mismatch,
+                        snapshot.buildId,
+                        snapshot.kernelRelease,
+                        profile.supportedExactBuilds,
+                    )
                 }
                 appendLog(app.getString(R.string.log_profile, profile.profileId))
                 updateHistoryProfile(profile.profileId)
@@ -163,7 +172,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 appendLog(app.getString(R.string.log_download_verified))
 
                 setPhase(InstallPhase.Exploiting, app.getString(R.string.status_exploit_running))
-                executeExploit(payloads.exploit)
+                executeExploit(payloads.exploit, profile)
 
                 setPhase(InstallPhase.LoadingKernelSu, app.getString(R.string.status_ksu_loading))
                 installKernelSu(payloads)
@@ -179,7 +188,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    private suspend fun executeExploit(payload: File) {
+    private suspend fun executeExploit(payload: File, profile: TargetProfile) {
         val shizuku = shizukuEnabled()
         val logFile = if (shizuku) File(SHIZUKU_LOG_PATH) else File(app.filesDir, "exploit.log")
         if (shizuku) {
@@ -197,7 +206,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             val stagedPayload = shizukuStage(payload, SHIZUKU_PAYLOAD_PATH, "755")
             ShizukuController.exec(
                 arrayOf("/system/bin/sh", "-c", "true"),
-                shizukuEnvironment(bootToken, stagedPayload.absolutePath, helper.absolutePath),
+                shizukuEnvironment(
+                    bootToken,
+                    stagedPayload.absolutePath,
+                    helper.absolutePath,
+                    profile,
+                ),
             )
         } else {
             val processBuilder = ProcessBuilder(
@@ -208,10 +222,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 logFile.absolutePath,
             ).redirectErrorStream(true)
             processBuilder.environment().apply {
-                put("EXPLOIT_ATTEMPTS", EXPLOIT_ATTEMPTS)
+                put("EXPLOIT_ATTEMPTS", profile.exploitAttempts.toString())
                 put("P0_ATTEMPT_TIMEOUT_SEC", P0_ATTEMPT_TIMEOUT_SEC)
                 put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", EXPLOIT_ATTEMPT_TIMEOUT_SEC)
-                cachedP0Offset(bootToken)?.let { put(P0_OFFSET_ENV, it) }
+                if (!profile.requiresFreshP0Session) {
+                    cachedP0Offset(bootToken)?.let { put(P0_OFFSET_ENV, it) }
+                }
             }
             processBuilder.start()
         }
@@ -399,13 +415,16 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         bootToken: String?,
         payloadPath: String,
         helperPath: String,
+        profile: TargetProfile,
     ): Array<String> = buildList {
-        add("EXPLOIT_ATTEMPTS=$EXPLOIT_ATTEMPTS")
+        add("EXPLOIT_ATTEMPTS=${profile.exploitAttempts}")
         add("P0_ATTEMPT_TIMEOUT_SEC=$P0_ATTEMPT_TIMEOUT_SEC")
         add("EXPLOIT_ATTEMPT_TIMEOUT_SEC=$EXPLOIT_ATTEMPT_TIMEOUT_SEC")
         add("CVE43499_ROOT_HELPER=$helperPath")
         add("LD_PRELOAD=$payloadPath")
-        cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
+        if (!profile.requiresFreshP0Session) {
+            cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
+        }
     }.toTypedArray()
 
     private fun readProcessOutput(process: Process, shizuku: Boolean): String {
@@ -482,7 +501,6 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     private fun File.readTextIfPresent(): String = if (exists()) readText() else ""
 
     companion object {
-        private const val EXPLOIT_ATTEMPTS = "24"
         private const val P0_ATTEMPT_TIMEOUT_SEC = "45"
         private const val EXPLOIT_ATTEMPT_TIMEOUT_SEC = "120"
         private const val EXPLOIT_STALL_MILLIS = 90_000L

--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -18,7 +18,7 @@ data class VerifiedPayloads(
 class PayloadRepository(private val context: Context) {
     fun loadTargets(): List<TargetProfile> {
         val commit = resolveMainCommit()
-        val manifestBytes = downloadBytes(rawUrl(commit, "support/targets-v3.json"), MAX_MANIFEST_BYTES)
+        val manifestBytes = downloadBytes(rawUrl(commit, "support/targets-v4.json"), MAX_MANIFEST_BYTES)
         return SupportManifest.parse(manifestBytes).targets.map { profile -> profile.copy(
             exploit = profile.exploit.copy(url = pinArtifactUrl(profile.exploit.url, commit)),
             kernelSu = profile.kernelSu.copy(url = pinArtifactUrl(profile.kernelSu.url, commit)),

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -13,12 +13,17 @@ data class TargetProfile(
     val displayName: String,
     val models: Set<String>,
     val kernelVersions: Set<String>,
+    val kernelReleases: Set<String> = emptySet(),
+    val buildIds: Set<String> = emptySet(),
+    val exploitAttempts: Int = 24,
+    val requiresFreshP0Session: Boolean = false,
     val exploit: RemoteArtifact,
     val kernelSu: RemoteArtifact,
 ) {
     init {
         require(models.isNotEmpty()) { "Payload must support at least one model" }
         require(kernelVersions.isNotEmpty()) { "Payload must support at least one kernel version" }
+        require(exploitAttempts in 1..24) { "Exploit attempts must be between 1 and 24" }
     }
 
     fun matchesDevice(snapshot: DeviceSnapshot): Boolean =
@@ -27,14 +32,21 @@ data class TargetProfile(
     fun matchesKernelVersion(snapshot: DeviceSnapshot): Boolean =
         snapshot.kernelVersion in kernelVersions
 
+    fun matchesExactBuild(snapshot: DeviceSnapshot): Boolean =
+        (kernelReleases.isEmpty() || snapshot.kernelRelease in kernelReleases) &&
+            (buildIds.isEmpty() || snapshot.buildId in buildIds)
+
     fun matches(snapshot: DeviceSnapshot): Boolean =
-        matchesDevice(snapshot) && matchesKernelVersion(snapshot)
+        matchesDevice(snapshot) && matchesKernelVersion(snapshot) && matchesExactBuild(snapshot)
 
     val supportedModels: String
         get() = models.joinToString()
 
     val supportedKernelVersions: String
         get() = kernelVersions.joinToString()
+
+    val supportedExactBuilds: String
+        get() = buildIds.ifEmpty { kernelReleases }.joinToString()
 }
 
 data class SupportManifest(
@@ -45,7 +57,7 @@ data class SupportManifest(
         fun parse(bytes: ByteArray): SupportManifest {
             val root = JSONObject(bytes.toString(Charsets.UTF_8))
             val schemaVersion = root.getInt("schemaVersion")
-            require(schemaVersion == 3) { "Unsupported support manifest schema" }
+            require(schemaVersion == 4) { "Unsupported support manifest schema" }
             val payloadsJson = root.getJSONArray("payloads")
             val payloads = buildList {
                 for (index in 0 until payloadsJson.length()) {
@@ -58,6 +70,10 @@ data class SupportManifest(
                             displayName = payload.getString("displayName"),
                             models = payload.getJSONArray("models").strings(),
                             kernelVersions = payload.getJSONArray("kernelVersions").strings(),
+                            kernelReleases = payload.optJSONArray("kernelReleases")?.strings().orEmpty(),
+                            buildIds = payload.optJSONArray("buildIds")?.strings().orEmpty(),
+                            exploitAttempts = payload.optInt("exploitAttempts", 24),
+                            requiresFreshP0Session = payload.optBoolean("requiresFreshP0Session", false),
                             exploit = RemoteArtifact(
                                 url = exploit.getString("url"),
                                 size = exploit.getLong("size"),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="error_exploit_timeout">The exploit exceeded the 15-minute limit</string>
     <string name="error_payload_exit">Payload execution failed: %1$d%2$s</string>
     <string name="error_success_marker">Exploit success markers were not found</string>
+    <string name="error_exact_build_mismatch">This payload is not built for firmware %1$s (%2$s). Supported exact build: %3$s. Exact firmware checks cannot be overridden.</string>
     <string name="error_ksu_stage">KernelSU staging failed: %1$s</string>
     <string name="error_ksu_verify">KernelSU late-load or control verification failed (rc=%1$d): %2$s</string>
     <string name="error_boot_id">Unable to read the current boot_id</string>
@@ -117,7 +118,7 @@
 
     <string name="artifact_exploit">exploit</string>
     <string name="artifact_kernelsu">KernelSU</string>
-    <string name="repo_no_profile">No compatible payload supports this model and kernel version</string>
+    <string name="repo_no_profile">No compatible payload supports this exact model, kernel, and firmware build</string>
     <string name="repo_downloading">Downloading %1$s</string>
     <string name="repo_size_mismatch">%1$s size does not match the support manifest</string>
     <string name="repo_size_exceeded">%1$s exceeded the declared size</string>

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -1,7 +1,9 @@
 package dev.busung.s25uroot
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class TargetProfileTest {
@@ -26,15 +28,84 @@ class TargetProfileTest {
         assertFalse(profile.matches(snapshot("SM-S938N", "6.6.102-android15-8-build")))
     }
 
+    @Test
+    fun rejectsDifferentFirmwareWhenProfileDeclaresExactBuild() {
+        val exactProfile = profile.copy(
+            models = setOf("SM-S928U"),
+            kernelVersions = setOf("6.1.145"),
+            kernelReleases = setOf("6.1.145-android14-11-33419968-abS928USQS6DZF2"),
+            buildIds = setOf("BP4A.251205.006.S928USQS6DZF2"),
+        )
+
+        assertTrue(
+            exactProfile.matches(
+                snapshot(
+                    "SM-S928U",
+                    "6.1.145-android14-11-33419968-abS928USQS6DZF2",
+                    "BP4A.251205.006.S928USQS6DZF2",
+                ),
+            ),
+        )
+        assertFalse(
+            exactProfile.matches(
+                snapshot(
+                    "SM-S928U",
+                    "6.1.145-android14-11-33419968-abS928USQS6DZG1",
+                    "BP4A.251205.006.S928USQS6DZG1",
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun parsesExactBuildAndAttemptControls() {
+        val manifest = SupportManifest.parse(
+            """
+            {
+              "schemaVersion": 4,
+              "payloads": [{
+                "payloadId": "e3q-test",
+                "displayName": "E3Q test",
+                "models": ["SM-S928U"],
+                "kernelVersions": ["6.1.145"],
+                "kernelReleases": ["release-exact"],
+                "buildIds": ["build-exact"],
+                "exploitAttempts": 1,
+                "requiresFreshP0Session": true,
+                "exploit": {"url": "https://example.invalid/exploit", "size": 1},
+                "kernelsu": {"url": "https://example.invalid/ksud", "size": 1}
+              }]
+            }
+            """.trimIndent().toByteArray(),
+        ).targets.single()
+
+        assertEquals(setOf("release-exact"), manifest.kernelReleases)
+        assertEquals(setOf("build-exact"), manifest.buildIds)
+        assertEquals(1, manifest.exploitAttempts)
+        assertTrue(manifest.requiresFreshP0Session)
+    }
+
+    @Test
+    fun rejectsLegacyManifestWithoutExactBuildSemantics() {
+        assertThrows(IllegalArgumentException::class.java) {
+            SupportManifest.parse(
+                """{"schemaVersion":3,"payloads":[]}""".toByteArray(),
+            )
+        }
+    }
+
     private fun snapshot(
         model: String,
         kernelRelease: String,
+        buildId: String = "BP4A.251205.006.S938BCZG1",
     ) = DeviceSnapshot(
         manufacturer = "samsung",
         model = model,
         device = "unused",
         kernelRelease = kernelRelease,
-        buildId = "BP4A.251205.006.S938BCZG1",
+        kernelVersionInfo = "#1 SMP PREEMPT",
+        machine = "aarch64",
+        buildId = buildId,
         fingerprint = "samsung/example",
         androidRelease = "16",
         sdk = 36,


### PR DESCRIPTION
## Summary

Make payload selection fail closed on exact firmware identity instead of matching only the device model.

- Requires support-manifest schema v4.
- Matches `model`, exact `kernelRelease`, and exact Android `buildId`.
- Applies the same checks to manual target selection.
- Supports per-profile exploit-attempt limits and fresh-P0-session requirements.
- Adds unit tests for exact matching and mismatch rejection.
- Runs unit tests before producing the debug APK in CI.

## Why

On `SM-S928U / S928USQS6DZG1`, the legacy model-only feed can select the older DZF2 payload. That mismatch has already caused device crashes. This change prevents the app from downloading or running a payload unless the full firmware identity matches.

## Dependency / deployment order

This PR depends on payload PR https://github.com/BuSung-dev/Root-My-Galaxy-Payloads/pull/195 and must be merged only after that payload/feed PR is available on the payload repository's main branch.

The exact DZG1 profile remains hardware-unvalidated; the companion payload PR intentionally limits it to one attempt and a fresh P0 session.