### PR TITLE
Compare staged payload content, not length

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.InputStream
+import java.security.MessageDigest
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -49,6 +50,30 @@ data class TargetCatalogUiState(
 )
 
 private data class CommandResult(val code: Int, val output: String)
+
+/**
+ * Payloads are truncated to a fixed release size, so a rebuild of a target --
+ * or a different target padded to the same size -- has exactly the length of
+ * whatever is already staged, and would keep running in its place.
+ */
+internal fun stagedFileIsCurrent(staged: File, source: File): Boolean {
+    if (!staged.exists()) return false
+    val stagedDigest = sha256OrNull(staged) ?: return false
+    return stagedDigest == sha256OrNull(source)
+}
+
+private fun sha256OrNull(file: File): String? = runCatching {
+    file.inputStream().use { input ->
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(8192)
+        while (true) {
+            val count = input.read(buffer)
+            if (count < 0) break
+            digest.update(buffer, 0, count)
+        }
+        digest.digest().joinToString("") { "%02x".format(it) }
+    }
+}.getOrNull()
 
 class InstallViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application
@@ -383,7 +408,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
     private fun shizukuStage(source: File, target: String, mode: String): File {
         val staged = File(target)
-        if (staged.exists() && staged.length() == source.length()) return staged
+        if (stagedFileIsCurrent(staged, source)) return staged
         try {
             ShizukuController.writeFile(target, mode, source.inputStream())
         } catch (error: Throwable) {

--- a/app/src/test/java/dev/busung/s25uroot/StagedFileIsCurrentTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/StagedFileIsCurrentTest.kt
@@ -1,0 +1,61 @@
+package dev.busung.s25uroot
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StagedFileIsCurrentTest {
+    @Test
+    fun restagesWhenContentDiffersAtIdenticalLength() {
+        val source = file("payload", ByteArray(104128) { 0xAA.toByte() })
+        val staged = file("staged", ByteArray(104128) { 0xBB.toByte() })
+
+        assertTrue("fixture must reproduce the equal-length case", staged.length() == source.length())
+        assertFalse(stagedFileIsCurrent(staged, source))
+    }
+
+    @Test
+    fun reusesWhenContentIsIdentical() {
+        val bytes = ByteArray(104128) { (it % 251).toByte() }
+
+        assertTrue(stagedFileIsCurrent(file("staged", bytes), file("payload", bytes)))
+    }
+
+    @Test
+    fun restagesWhenNothingIsStagedYet() {
+        val source = file("payload", byteArrayOf(1, 2, 3))
+        val missing = File(Files.createTempDirectory("stage-test").toFile(), "absent")
+
+        assertFalse(stagedFileIsCurrent(missing, source))
+    }
+
+    @Test
+    fun restagesWhenTheStagedFileCannotBeRead() {
+        val source = file("payload", byteArrayOf(1, 2, 3))
+        val unreadable = File(Files.createTempDirectory("stage-test").toFile(), "dir").apply { mkdirs() }
+
+        assertFalse(stagedFileIsCurrent(unreadable, source))
+    }
+
+    @Test
+    fun restagesWhenNeitherFileCanBeRead() {
+        val root = Files.createTempDirectory("stage-test").toFile()
+        val stagedDir = File(root, "staged").apply { mkdirs() }
+        val sourceDir = File(root, "source").apply { mkdirs() }
+
+        assertFalse(stagedFileIsCurrent(stagedDir, sourceDir))
+    }
+
+    @Test
+    fun restagesWhenLengthsDifferToo() {
+        val source = file("payload", ByteArray(104128) { 0xAA.toByte() })
+        val staged = file("staged", ByteArray(4096) { 0xAA.toByte() })
+
+        assertFalse(stagedFileIsCurrent(staged, source))
+    }
+
+    private fun file(name: String, bytes: ByteArray): File =
+        File(Files.createTempDirectory("stage-test").toFile(), name).apply { writeBytes(bytes) }
+}

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -34,6 +34,8 @@ class TargetProfileTest {
         model = model,
         device = "unused",
         kernelRelease = kernelRelease,
+        kernelVersionInfo = "#1 SMP PREEMPT",
+        machine = "aarch64",
         buildId = "BP4A.251205.006.S938BCZG1",
         fingerprint = "samsung/example",
         androidRelease = "16",


### PR DESCRIPTION
`shizukuStage` skips re-staging when the file already at the target path has the same length as the source. Payloads are truncated to a fixed release size, so a rebuild of a target — or a different target padded to that same size, which is 6 of the 10 profiles `targets-v3.json` currently serves — has exactly the length of whatever is already staged. The comparison cannot observe the difference, and the first payload written to `/data/local/tmp/ksu-payload` keeps running in place of every payload staged after it.

### How it shows up

On an SM-S9280, a payload staged on 2026-08-07 was still the one executing six days later, across several imports of different payloads. Nothing surfaces it: staging reports success and the exploit runs normally, it just runs the wrong binary. The only tell is in the exploit's own log, where the build reports constants belonging to a target that was no longer the one being installed.

A panic reboot, which reverts recent writes under `/data/local/tmp`, is invisible for the same reason.

All four `shizukuStage` call sites are affected — payload, helper, and both ksud paths — but only with Shizuku mode on. The direct path executes the app's own files in place and copies ksud unconditionally, so it has no staleness to hit.

### The change

The comparison moves to SHA-256, behind `stagedFileIsCurrent` so the rule can be tested without an Android context. A staged file that cannot be read is treated as not current and re-staged, rather than letting two unreadable paths compare equal.

Two of the six new cases fail against the length comparison and pass against the digest: content differing at identical length, and two unreadable paths.

This costs a digest of both files per staged artifact, roughly 20 MB of reads per run, dominated by hashing ksud twice for its two paths. It also recovers from a partial write, which a length comparison can leave in place indefinitely.

### Verification

`assembleDebug` and `testDebugUnitTest` pass, and each commit builds on its own.

The changed function and its call site are byte-identical to a fork where this was exercised on an SM-S9280: after the change the app staged the expected payload, confirmed by SHA-256 on the device and by the build constants in the exploit log. This branch itself was not installed on hardware.

### On the first commit

`TargetProfileTest` needs `kernelVersionInfo` and `machine` to compile — `DeviceSnapshot` gained them without the fixture being updated, so `testDebugUnitTest` does not currently compile on `main`. It is kept as a separate commit; without it the new test cannot run at all.

CI runs only `assembleDebug`, which is why that went unnoticed. It also means the tests added here will not run in CI as currently configured.
