### PR TITLE
Enable R8 on release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,27 @@ android {
         buildConfig = true
     }
 
+    buildTypes {
+        debug {
+            isDebuggable = true
+            isMinifyEnabled = false
+            isShrinkResources = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+        release {
+            isDebuggable = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,10 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+-repackageclasses
+-allowaccessmodification
+-overloadaggressively

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -51,7 +51,6 @@
     <string name="history_detail_title">Detalhes da execução</string>
     <string name="history_started">Começou: %1$s</string>
     <string name="history_completed">Completou: %1$s</string>
-    <string name="history_log">Logs de execução</string>
     <string name="history_log_empty">Nenhum output de log por enquanto.</string>
 
     <string name="install_title">Instalar</string>


### PR DESCRIPTION
This PR allows to reduce the size of the final apk from 62MB-ish to 2MB.