### PR TITLE
Harden non-Shizuku install path

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -60,6 +60,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     private var discoveryJob: Job? = null
     private var installJob: Job? = null
     private var activeHistoryEntry: InstallHistoryEntry? = null
+
+    @Volatile
+    private var activeRunShizuku: Boolean? = null
     val state: StateFlow<InstallUiState> = mutableState.asStateFlow()
     val history: StateFlow<List<InstallHistoryEntry>> = mutableHistory.asStateFlow()
     val targetCatalog: StateFlow<TargetCatalogUiState> = mutableTargetCatalog.asStateFlow()
@@ -138,6 +141,10 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 probeOutput = mutableState.value.probeOutput,
             )
             startHistory()
+            // Freeze the transport for the whole run so a mid-run preference
+            // change cannot mix Shizuku and standalone execution between the
+            // exploit and the KernelSU staging steps.
+            activeRunShizuku = AppPreferences.shizukuMode(app)
             try {
                 if (shizukuEnabled()) {
                     appendLog(app.getString(R.string.log_shizuku_prepare))
@@ -175,6 +182,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 appendLog("[-] ${error.message ?: error.javaClass.simpleName}")
                 setPhase(InstallPhase.Failed, app.getString(R.string.status_install_failed))
                 finishHistory(InstallRunResult.Failed)
+            } finally {
+                activeRunShizuku = null
             }
         }
     }
@@ -219,7 +228,10 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         val readLog: () -> String = if (shizuku) {
             { drainProcessOutput(process, captured) }
         } else {
-            { logFile.readTextIfPresent() }
+            // Keep draining stdout while polling: if the helper fills the OS
+            // pipe buffer it blocks on write and stops making log progress,
+            // which would trip the stall detector spuriously.
+            { drainProcessOutput(process, captured); logFile.readTextIfPresent() }
         }
 
         try {
@@ -248,7 +260,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             val rawLog = readLog()
             cacheP0Offset(bootToken, rawLog)
             publishExploitLog(logPrefix, rawLog)
-            val earlyOutput = readProcessOutput(process, shizuku).trim()
+            // Both transports drain into `captured` during the poll loop, so
+            // this never blocks on a child still holding the pipe open.
+            val earlyOutput = captured.toString().trim()
             require(exitCode == 0) {
                 app.getString(
                     R.string.error_payload_exit,
@@ -297,7 +311,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         updateHistoryLog()
     }
 
-    private fun installKernelSu(payloads: VerifiedPayloads) {
+    private suspend fun installKernelSu(payloads: VerifiedPayloads) {
         if (shizukuEnabled()) {
             shizukuStage(payloads.kernelSu, SHIZUKU_KSUD_PATH, "755")
             shizukuStage(payloads.kernelSu, SHIZUKU_KSUD_STAGE_PATH, "755")
@@ -305,9 +319,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         } else {
             val source = shellQuote(payloads.kernelSu.absolutePath)
             val stageCommand =
-                "/system/bin/cp $source /data/local/tmp/ksud-s25u-kdp && " +
-                    "/system/bin/cp $source /data/local/tmp/.ksud-stage && " +
-                    "/system/bin/chmod 755 /data/local/tmp/ksud-s25u-kdp /data/local/tmp/.ksud-stage"
+                "/system/bin/cp $source $SHIZUKU_KSUD_PATH && " +
+                    "/system/bin/cp $source $SHIZUKU_KSUD_STAGE_PATH && " +
+                    "/system/bin/chmod 755 $SHIZUKU_KSUD_PATH $SHIZUKU_KSUD_STAGE_PATH"
             val stage = runHelper("-c", stageCommand)
             require(stage.code == 0) { app.getString(R.string.error_ksu_stage, stage.output) }
             appendLog(app.getString(R.string.log_ksu_staged))
@@ -379,7 +393,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
     private fun nativeHelperFile() = File(app.applicationInfo.nativeLibraryDir, "libcve43499root.so")
 
-    private fun shizukuEnabled(): Boolean = AppPreferences.shizukuMode(app)
+    private fun shizukuEnabled(): Boolean = activeRunShizuku ?: AppPreferences.shizukuMode(app)
 
     private fun shizukuStage(source: File, target: String, mode: String): File {
         val staged = File(target)
@@ -408,13 +422,14 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
     }.toTypedArray()
 
-    private fun readProcessOutput(process: Process, shizuku: Boolean): String {
-        val stdout = process.inputStream.bufferedReader().use { it.readText() }
-        val stderr = if (shizuku) process.errorStream.bufferedReader().use { it.readText() } else ""
-        return stdout + stderr
-    }
-
-    private fun runHelper(vararg arguments: String): CommandResult {
+    /**
+     * Runs the bootstrap helper for a short management command. Unlike the
+     * exploit run there is no log file to poll, so output is drained inline
+     * and a hard deadline guards against a helper that never exits — without
+     * this, a hung `--late-load` leaves the install stuck in LoadingKernelSu
+     * indefinitely.
+     */
+    private suspend fun runHelper(vararg arguments: String): CommandResult {
         val helper = helperFile()
         val process = if (shizukuEnabled()) {
             ShizukuController.exec(arrayOf(helper.absolutePath) + arguments)
@@ -423,8 +438,30 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 .redirectErrorStream(true)
                 .start()
         }
-        val output = readProcessOutput(process, shizukuEnabled())
-        return CommandResult(process.waitFor(), stripAnsi(output.trim()))
+        val captured = StringBuilder()
+        val startedAt = SystemClock.elapsedRealtime()
+        try {
+            while (process.isAlive) {
+                drainProcessOutput(process, captured)
+                require(SystemClock.elapsedRealtime() - startedAt < HELPER_TIMEOUT_MILLIS) {
+                    app.getString(
+                        R.string.error_helper_timeout,
+                        captured.toString().trim().takeIf(String::isNotBlank)
+                            ?.let { ": $it" } ?: "",
+                    )
+                }
+                delay(HELPER_POLL_INTERVAL)
+            }
+            drainProcessOutput(process, captured)
+            val exitCode = process.waitFor()
+            return CommandResult(exitCode, stripAnsi(captured.toString().trim()))
+        } finally {
+            if (process.isAlive) {
+                process.destroy()
+                delay(500.milliseconds)
+                if (process.isAlive) process.destroyForcibly()
+            }
+        }
     }
 
     private fun shellQuote(value: String) = "'${value.replace("'", "'\\''")}'"
@@ -487,6 +524,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val EXPLOIT_ATTEMPT_TIMEOUT_SEC = "120"
         private const val EXPLOIT_STALL_MILLIS = 90_000L
         private const val EXPLOIT_TOTAL_MILLIS = 900_000L
+        private const val HELPER_TIMEOUT_MILLIS = 120_000L
         private const val INSTALL_RECEIPT = "install_receipt"
         private const val RECEIPT_BOOT_TOKEN = "kernel_boot_id"
         private const val RECEIPT_VERIFIED = "verified"
@@ -502,6 +540,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val SHIZUKU_KSUD_PATH = "/data/local/tmp/ksud-s25u-kdp"
         private const val SHIZUKU_KSUD_STAGE_PATH = "/data/local/tmp/.ksud-stage"
         private val LOG_POLL_INTERVAL = 250.milliseconds
+        private val HELPER_POLL_INTERVAL = 250.milliseconds
         private val SHIZUKU_LOG_POLL_INTERVAL = 1.seconds
         private val ANSI_ESCAPE = Regex("\u001B\\[[0-?]*[ -/]*[@-~]")
         private val P0_OFFSET_PATTERN = Regex(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="error_success_marker">Exploit success markers were not found</string>
     <string name="error_ksu_stage">KernelSU staging failed: %1$s</string>
     <string name="error_ksu_verify">KernelSU late-load or control verification failed (rc=%1$d): %2$s</string>
+    <string name="error_helper_timeout">KernelSU helper did not exit within 120 seconds%1$s</string>
     <string name="error_boot_id">Unable to read the current boot_id</string>
     <string name="error_receipt">Unable to save the installation verification receipt</string>
 

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -34,6 +34,8 @@ class TargetProfileTest {
         model = model,
         device = "unused",
         kernelRelease = kernelRelease,
+        kernelVersionInfo = "#1 SMP PREEMPT test",
+        machine = "aarch64",
         buildId = "BP4A.251205.006.S938BCZG1",
         fingerprint = "samsung/example",
         androidRelease = "16",


### PR DESCRIPTION
Three failure-path fixes in `InstallViewModel`, no functional/UX change otherwise. No new permissions, components, or download behavior.

### 1. Unbounded block on helper commands
`runHelper()` (used for `-c` staging and `--late-load`) did `readText()` + `waitFor()` with no deadline. A helper that never exits leaves the install stuck at *Late-loading KernelSu* forever. Now polled every 250 ms with a 120 s deadline; on timeout the process is destroyed (escalating to `destroyForcibly()`) and the failure surfaces with captured output via the new `error_helper_timeout` string.

### 2. Undrained stdout during the exploit run
The non-Shizuku branch read the helper's merged stdout only *after* exit. If the helper outpaces the ~64 KB pipe buffer it blocks on write, stops making log progress, and trips the 90 s stall detector spuriously. Output is now drained into a buffer during polling; that buffer also replaces the post-exit blocking read (which could additionally stall on an orphaned grandchild holding the write end).

### 3. Transport mode re-read per call site
`shizukuEnabled()` consulted the preference inside `executeExploit`, `installKernelSu`, `helperFile` and `runHelper` independently, so flipping Shizuku mode mid-run switched remaining steps to a different transport. The mode is now captured once when the run starts and cleared when it ends.

### Also
- Staging command reuses the existing `SHIZUKU_KSUD*` constants instead of duplicated literals (identical paths)
- `TargetProfileTest` updated for the current `DeviceSnapshot` signature (was failing compilation)

Unit tests pass; compiled clean against current `main`.
