### PR TITLE
Re-establish root automatically at boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <queries>
         <package android:name="me.weishu.kernelsu" />
@@ -32,6 +36,18 @@
             android:exported="true"
             android:multiprocess="false"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
+        <service
+            android:name=".BootInstallService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync"
+            android:stopWithTask="false" />
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
         <activity
             android:name=".InstallActivity"
             android:exported="false" />

--- a/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
+++ b/app/src/main/java/dev/busung/s25uroot/AppPreferences.kt
@@ -34,6 +34,7 @@ object AppPreferences {
     private const val THEME_MODE = "theme_mode"
     private const val ADVANCED_MODE = "advanced_mode"
     private const val SHIZUKU_MODE = "shizuku_mode"
+    private const val BOOT_ROOT_MODE = "boot_root_mode"
     private const val CONSUMED_INSTALL_REQUEST = "consumed_install_request"
 
     fun accentColor(context: Context): AccentColor = AccentColor.fromStoredValue(
@@ -71,6 +72,15 @@ object AppPreferences {
     fun setShizukuMode(context: Context, enabled: Boolean) {
         prefs(context).edit()
             .putBoolean(SHIZUKU_MODE, enabled)
+            .apply()
+    }
+
+    fun bootRootMode(context: Context): Boolean =
+        prefs(context).getBoolean(BOOT_ROOT_MODE, false)
+
+    fun setBootRootMode(context: Context, enabled: Boolean) {
+        prefs(context).edit()
+            .putBoolean(BOOT_ROOT_MODE, enabled)
             .apply()
     }
 

--- a/app/src/main/java/dev/busung/s25uroot/BootInstallService.kt
+++ b/app/src/main/java/dev/busung/s25uroot/BootInstallService.kt
@@ -1,0 +1,149 @@
+package dev.busung.s25uroot
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Foreground service that runs the standalone install path at boot.
+ *
+ * Forces Shizuku mode off for the duration of the run, so the exploit runs
+ * directly in the app's own process. Artifacts are fetched through the
+ * normal commit-pinned download flow, so this needs connectivity shortly
+ * after boot.
+ *
+ * The service stops itself when the install reaches a terminal phase
+ * (Installed / Failed). It is not restarted by the system afterwards;
+ * re-running happens on the next boot or from the app UI.
+ */
+class BootInstallService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val notificationId = 0x42554f54
+
+    private var previousShizukuMode: Boolean? = null
+
+    private lateinit var viewModel: InstallViewModel
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        // Capture the user's preference so the boot run forces standalone mode
+        // without permanently changing the setting. Shizuku is generally not
+        // reachable at boot time.
+        previousShizukuMode = AppPreferences.shizukuMode(this)
+        AppPreferences.setShizukuMode(this, false)
+        viewModel = ViewModelProvider.AndroidViewModelFactory.getInstance(application)
+            .create(InstallViewModel::class.java)
+        startForeground(
+            notificationId,
+            buildNotification(getString(R.string.status_checking_github)),
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        scope.launch {
+            viewModel.state.collectLatest { state ->
+                val title = when (state.phase) {
+                    InstallPhase.Exploiting -> getString(R.string.status_exploit_running)
+                    InstallPhase.LoadingKernelSu -> getString(R.string.status_ksu_loading)
+                    InstallPhase.Installed -> getString(R.string.status_ksu_active)
+                    InstallPhase.Failed -> getString(R.string.status_install_failed)
+                    else -> getString(R.string.status_checking_github)
+                }
+                val text = state.log.lineSequence().lastOrNull()?.take(120)
+                    ?: state.message
+                notify(title, text)
+                if (state.phase == InstallPhase.Installed || state.phase == InstallPhase.Failed) {
+                    stopSelf()
+                }
+            }
+        }
+        scope.launch {
+            viewModel.install()
+        }
+        return START_NOT_STICKY
+    }
+
+    override fun onDestroy() {
+        previousShizukuMode?.let { AppPreferences.setShizukuMode(this, it) }
+        scope.cancel()
+        stopForegroundCompat()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun notify(title: String, text: String) {
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.notify(notificationId, buildNotification(title, text))
+    }
+
+    private fun buildNotification(title: String, text: String = "") =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.stat_sys_warning)
+            .setContentTitle(title)
+            .setContentText(text)
+            .setContentIntent(launcherPendingIntent())
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+    private fun launcherPendingIntent(): PendingIntent {
+        val intent = Intent(this, MainActivity::class.java)
+        return PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.notification_channel_boot),
+                NotificationManager.IMPORTANCE_LOW,
+            )
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun stopForegroundCompat() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        } else {
+            @Suppress("DEPRECATION")
+            stopForeground(true)
+        }
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "boot_install"
+
+        fun start(context: Context) {
+            val intent = Intent(context, BootInstallService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/busung/s25uroot/BootInstallService.kt
+++ b/app/src/main/java/dev/busung/s25uroot/BootInstallService.kt
@@ -118,7 +118,7 @@ class BootInstallService : Service() {
             val channel = NotificationChannel(
                 CHANNEL_ID,
                 getString(R.string.notification_channel_boot),
-                NotificationManager.IMPORTANCE_LOW,
+                NotificationManager.IMPORTANCE_DEFAULT,
             )
             getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
         }

--- a/app/src/main/java/dev/busung/s25uroot/BootReceiver.kt
+++ b/app/src/main/java/dev/busung/s25uroot/BootReceiver.kt
@@ -1,0 +1,18 @@
+package dev.busung.s25uroot
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Re-establishes root after a reboot: on these targets KernelSU is loaded as
+ * a runtime module and nothing persists across power cycles, so the install
+ * has to run again every boot. Skips when the module is already active.
+ */
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+        if (NativeProbe.isKernelSuActive()) return
+        BootInstallService.start(context)
+    }
+}

--- a/app/src/main/java/dev/busung/s25uroot/BootReceiver.kt
+++ b/app/src/main/java/dev/busung/s25uroot/BootReceiver.kt
@@ -13,6 +13,7 @@ class BootReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
         if (NativeProbe.isKernelSuActive()) return
+        if (!AppPreferences.bootRootMode(context)) return
         BootInstallService.start(context)
     }
 }

--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -60,6 +60,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     private var discoveryJob: Job? = null
     private var installJob: Job? = null
     private var activeHistoryEntry: InstallHistoryEntry? = null
+
+    @Volatile
+    private var activeRunShizuku: Boolean? = null
     val state: StateFlow<InstallUiState> = mutableState.asStateFlow()
     val history: StateFlow<List<InstallHistoryEntry>> = mutableHistory.asStateFlow()
     val targetCatalog: StateFlow<TargetCatalogUiState> = mutableTargetCatalog.asStateFlow()
@@ -138,6 +141,10 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 probeOutput = mutableState.value.probeOutput,
             )
             startHistory()
+            // Freeze the transport for the whole run so a mid-run preference
+            // change cannot mix Shizuku and standalone execution between the
+            // exploit and the KernelSU staging steps.
+            activeRunShizuku = AppPreferences.shizukuMode(app)
             try {
                 if (shizukuEnabled()) {
                     appendLog(app.getString(R.string.log_shizuku_prepare))
@@ -175,6 +182,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 appendLog("[-] ${error.message ?: error.javaClass.simpleName}")
                 setPhase(InstallPhase.Failed, app.getString(R.string.status_install_failed))
                 finishHistory(InstallRunResult.Failed)
+            } finally {
+                activeRunShizuku = null
             }
         }
     }
@@ -219,7 +228,10 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         val readLog: () -> String = if (shizuku) {
             { drainProcessOutput(process, captured) }
         } else {
-            { logFile.readTextIfPresent() }
+            // Keep draining stdout while polling: if the helper fills the OS
+            // pipe buffer it blocks on write and stops making log progress,
+            // which would trip the stall detector spuriously.
+            { drainProcessOutput(process, captured); logFile.readTextIfPresent() }
         }
 
         try {
@@ -248,7 +260,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             val rawLog = readLog()
             cacheP0Offset(bootToken, rawLog)
             publishExploitLog(logPrefix, rawLog)
-            val earlyOutput = readProcessOutput(process, shizuku).trim()
+            // Both transports drain into `captured` during the poll loop, so
+            // this never blocks on a child still holding the pipe open.
+            val earlyOutput = captured.toString().trim()
             require(exitCode == 0) {
                 app.getString(
                     R.string.error_payload_exit,
@@ -297,7 +311,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         updateHistoryLog()
     }
 
-    private fun installKernelSu(payloads: VerifiedPayloads) {
+    private suspend fun installKernelSu(payloads: VerifiedPayloads) {
         if (shizukuEnabled()) {
             shizukuStage(payloads.kernelSu, SHIZUKU_KSUD_PATH, "755")
             shizukuStage(payloads.kernelSu, SHIZUKU_KSUD_STAGE_PATH, "755")
@@ -305,9 +319,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         } else {
             val source = shellQuote(payloads.kernelSu.absolutePath)
             val stageCommand =
-                "/system/bin/cp $source /data/local/tmp/ksud-s25u-kdp && " +
-                    "/system/bin/cp $source /data/local/tmp/.ksud-stage && " +
-                    "/system/bin/chmod 755 /data/local/tmp/ksud-s25u-kdp /data/local/tmp/.ksud-stage"
+                "/system/bin/cp $source $SHIZUKU_KSUD_PATH && " +
+                    "/system/bin/cp $source $SHIZUKU_KSUD_STAGE_PATH && " +
+                    "/system/bin/chmod 755 $SHIZUKU_KSUD_PATH $SHIZUKU_KSUD_STAGE_PATH"
             val stage = runHelper("-c", stageCommand)
             require(stage.code == 0) { app.getString(R.string.error_ksu_stage, stage.output) }
             appendLog(app.getString(R.string.log_ksu_staged))
@@ -379,7 +393,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
     private fun nativeHelperFile() = File(app.applicationInfo.nativeLibraryDir, "libcve43499root.so")
 
-    private fun shizukuEnabled(): Boolean = AppPreferences.shizukuMode(app)
+    private fun shizukuEnabled(): Boolean = activeRunShizuku ?: AppPreferences.shizukuMode(app)
 
     private fun shizukuStage(source: File, target: String, mode: String): File {
         val staged = File(target)
@@ -408,13 +422,14 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
     }.toTypedArray()
 
-    private fun readProcessOutput(process: Process, shizuku: Boolean): String {
-        val stdout = process.inputStream.bufferedReader().use { it.readText() }
-        val stderr = if (shizuku) process.errorStream.bufferedReader().use { it.readText() } else ""
-        return stdout + stderr
-    }
-
-    private fun runHelper(vararg arguments: String): CommandResult {
+    /**
+     * Runs the bootstrap helper for a short management command. Unlike the
+     * exploit run there is no log file to poll, so output is drained inline
+     * and a hard deadline guards against a helper that never exits — without
+     * this, a hung `--late-load` leaves the install stuck in LoadingKernelSu
+     * indefinitely.
+     */
+    private suspend fun runHelper(vararg arguments: String): CommandResult {
         val helper = helperFile()
         val process = if (shizukuEnabled()) {
             ShizukuController.exec(arrayOf(helper.absolutePath) + arguments)
@@ -423,8 +438,30 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 .redirectErrorStream(true)
                 .start()
         }
-        val output = readProcessOutput(process, shizukuEnabled())
-        return CommandResult(process.waitFor(), stripAnsi(output.trim()))
+        val captured = StringBuilder()
+        val startedAt = SystemClock.elapsedRealtime()
+        try {
+            while (process.isAlive) {
+                drainProcessOutput(process, captured)
+                require(SystemClock.elapsedRealtime() - startedAt < HELPER_TIMEOUT_MILLIS) {
+                    app.getString(
+                        R.string.error_helper_timeout,
+                        captured.toString().trim().takeIf(String::isNotBlank)
+                            ?.let { ": $it" } ?: "",
+                    )
+                }
+                delay(HELPER_POLL_INTERVAL)
+            }
+            drainProcessOutput(process, captured)
+            val exitCode = process.waitFor()
+            return CommandResult(exitCode, stripAnsi(captured.toString().trim()))
+        } finally {
+            if (process.isAlive) {
+                process.destroy()
+                delay(500.milliseconds)
+                if (process.isAlive) process.destroyForcibly()
+            }
+        }
     }
 
     private fun shellQuote(value: String) = "'${value.replace("'", "'\\''")}'"
@@ -487,6 +524,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val EXPLOIT_ATTEMPT_TIMEOUT_SEC = "120"
         private const val EXPLOIT_STALL_MILLIS = 90_000L
         private const val EXPLOIT_TOTAL_MILLIS = 900_000L
+        private const val HELPER_TIMEOUT_MILLIS = 120_000L
         private const val INSTALL_RECEIPT = "install_receipt"
         private const val RECEIPT_BOOT_TOKEN = "kernel_boot_id"
         private const val RECEIPT_VERIFIED = "verified"
@@ -502,6 +540,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val SHIZUKU_KSUD_PATH = "/data/local/tmp/ksud-s25u-kdp"
         private const val SHIZUKU_KSUD_STAGE_PATH = "/data/local/tmp/.ksud-stage"
         private val LOG_POLL_INTERVAL = 250.milliseconds
+        private val HELPER_POLL_INTERVAL = 250.milliseconds
         private val SHIZUKU_LOG_POLL_INTERVAL = 1.seconds
         private val ANSI_ESCAPE = Regex("\u001B\\[[0-?]*[ -/]*[@-~]")
         private val P0_OFFSET_PATTERN = Regex(

--- a/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
+++ b/app/src/main/java/dev/busung/s25uroot/MainActivity.kt
@@ -1,7 +1,9 @@
 package dev.busung.s25uroot
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -84,6 +86,7 @@ import androidx.compose.material.icons.rounded.SystemUpdate
 import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.VerifiedUser
+import androidx.compose.material.icons.rounded.RestartAlt
 import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -165,6 +168,22 @@ class MainActivity : ComponentActivity() {
     private var themeMode by mutableStateOf(AppThemeMode.System)
     private var advancedMode by mutableStateOf(false)
     private var shizukuMode by mutableStateOf(false)
+    private var bootRootMode by mutableStateOf(false)
+    private var notificationPermissionAsked = false
+    private val notificationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { }
+
+    /** Single POST_NOTIFICATIONS ask so the boot FGS notification is visible. */
+    private fun maybeRequestNotificationPermission() {
+        if (notificationPermissionAsked) return
+        notificationPermissionAsked = true
+        if (Build.VERSION.SDK_INT >= 33 &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+                PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -174,6 +193,7 @@ class MainActivity : ComponentActivity() {
         themeMode = AppPreferences.themeMode(this)
         advancedMode = AppPreferences.advancedMode(this)
         shizukuMode = AppPreferences.shizukuMode(this)
+        bootRootMode = AppPreferences.bootRootMode(this)
         setContent {
             RootMyGalaxyTheme(accentColor = accentColor, themeMode = themeMode) {
                 RootApp(
@@ -182,6 +202,8 @@ class MainActivity : ComponentActivity() {
                     themeMode = themeMode,
                     advancedMode = advancedMode,
                     shizukuMode = shizukuMode,
+                    bootRootMode = bootRootMode,
+                    requestNotificationPermission = ::maybeRequestNotificationPermission,
                     onAccentColorChanged = { color ->
                         AppPreferences.setAccentColor(this, color)
                         accentColor = color
@@ -197,6 +219,10 @@ class MainActivity : ComponentActivity() {
                     onShizukuModeChanged = { enabled ->
                         AppPreferences.setShizukuMode(this, enabled)
                         shizukuMode = enabled
+                    },
+                    onBootRootModeChanged = { enabled ->
+                        AppPreferences.setBootRootMode(this, enabled)
+                        bootRootMode = enabled
                     },
                     openInstaller = { profileId ->
                         val installer = Intent(this, InstallActivity::class.java)
@@ -279,10 +305,13 @@ private fun RootApp(
     themeMode: AppThemeMode,
     advancedMode: Boolean,
     shizukuMode: Boolean,
+    bootRootMode: Boolean,
     onAccentColorChanged: (AccentColor) -> Unit,
     onThemeModeChanged: (AppThemeMode) -> Unit,
     onAdvancedModeChanged: (Boolean) -> Unit,
     onShizukuModeChanged: (Boolean) -> Unit,
+    onBootRootModeChanged: (Boolean) -> Unit,
+    requestNotificationPermission: () -> Unit,
     openInstaller: (String?) -> Unit,
 ) {
     val installState by installViewModel.state.collectAsStateWithLifecycle()
@@ -475,6 +504,7 @@ private fun RootApp(
             when (page) {
                 AppPage.Overview -> OverviewPage(
                     padding = padding,
+                    requestNotificationPermission = requestNotificationPermission,
                     device = device,
                     installState = installState,
                     updateStatus = updateStatus,
@@ -502,6 +532,7 @@ private fun RootApp(
                     themeMode = themeMode,
                     advancedMode = advancedMode,
                     shizukuMode = shizukuMode,
+                    bootRootMode = bootRootMode,
                     updateStatus = updateStatus,
                     onCheckForUpdate = checkForUpdate,
                     onStartDownload = startDownload,
@@ -509,6 +540,7 @@ private fun RootApp(
                     onThemeModeChanged = onThemeModeChanged,
                     onAdvancedModeChanged = onAdvancedModeChanged,
                     onShizukuModeChanged = onShizukuModeChanged,
+                    onBootRootModeChanged = onBootRootModeChanged,
                 )
             }
         }
@@ -551,6 +583,7 @@ private fun DialogDimAmount(amount: Float) {
 private fun OverviewPage(
     padding: PaddingValues,
     device: DeviceSnapshot,
+    requestNotificationPermission: () -> Unit,
     installState: InstallUiState,
     updateStatus: UpdateStatus,
     updateCardDismissed: Boolean,
@@ -558,6 +591,7 @@ private fun OverviewPage(
     onStartDownload: (UpdateInfo) -> Unit,
     onInstall: () -> Unit,
 ) {
+    LaunchedEffect(Unit) { requestNotificationPermission() }
     LazyColumn(
         modifier = Modifier.fillMaxSize().padding(padding),
         contentPadding = PaddingValues(horizontal = 20.dp, vertical = 20.dp),
@@ -1405,6 +1439,7 @@ private fun SettingsPage(
     themeMode: AppThemeMode,
     advancedMode: Boolean,
     shizukuMode: Boolean,
+    bootRootMode: Boolean,
     updateStatus: UpdateStatus,
     onCheckForUpdate: () -> Unit,
     onStartDownload: (UpdateInfo) -> Unit,
@@ -1412,6 +1447,7 @@ private fun SettingsPage(
     onThemeModeChanged: (AppThemeMode) -> Unit,
     onAdvancedModeChanged: (Boolean) -> Unit,
     onShizukuModeChanged: (Boolean) -> Unit,
+    onBootRootModeChanged: (Boolean) -> Unit,
 ) {
     val context = LocalContext.current
     val view = LocalView.current
@@ -1539,7 +1575,7 @@ private fun SettingsPage(
                     title = stringResource(R.string.shizuku_mode),
                     description = stringResource(R.string.shizuku_mode_description),
                     checked = shizukuMode,
-                    position = SettingsCardPosition.Bottom,
+                    position = SettingsCardPosition.Middle,
                     onCheckedChange = { enabled ->
                         clickHaptic(view)
                         if (!enabled) {
@@ -1557,6 +1593,17 @@ private fun SettingsPage(
                                 }
                             }
                         }
+                    },
+                )
+                SettingsSwitchCard(
+                    icon = Icons.Rounded.RestartAlt,
+                    title = stringResource(R.string.settings_boot_root),
+                    description = stringResource(R.string.settings_boot_root_summary),
+                    checked = bootRootMode,
+                    position = SettingsCardPosition.Bottom,
+                    onCheckedChange = {
+                        clickHaptic(view)
+                        onBootRootModeChanged(it)
                     },
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="status_support_failed">Support check failed</string>
     <string name="status_checking_github">Checking GitHub support manifest</string>
     <string name="status_downloading_payload">Downloading payloads</string>
+    <string name="notification_channel_boot">Boot installation</string>
     <string name="status_exploit_running">Running kernel exploit</string>
     <string name="status_ksu_loading">Late-loading KernelSU</string>
     <string name="status_install_failed">Installation failed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="error_success_marker">Exploit success markers were not found</string>
     <string name="error_ksu_stage">KernelSU staging failed: %1$s</string>
     <string name="error_ksu_verify">KernelSU late-load or control verification failed (rc=%1$d): %2$s</string>
+    <string name="error_helper_timeout">KernelSU helper did not exit within 120 seconds%1$s</string>
     <string name="error_boot_id">Unable to read the current boot_id</string>
     <string name="error_receipt">Unable to save the installation verification receipt</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,8 @@
     <string name="advanced_mode_description">Manually choose a device-compatible payload during installation</string>
     <string name="shizuku_mode">Use Shizuku</string>
     <string name="shizuku_mode_description">Use Shizuku to run the payload. This can improve reliability.</string>
+    <string name="settings_boot_root">Root on boot</string>
+    <string name="settings_boot_root_summary">Automatically re-run the install after every reboot when root is not active</string>
     <string name="shizuku_not_running_title">Shizuku is not running</string>
     <string name="shizuku_not_running_body">Start the Shizuku service with adb or root and grant this app permission, then enable this option.</string>
     <string name="action_download_shizuku">Download Shizuku</string>

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -34,6 +34,8 @@ class TargetProfileTest {
         model = model,
         device = "unused",
         kernelRelease = kernelRelease,
+        kernelVersionInfo = "#1 SMP PREEMPT test",
+        machine = "aarch64",
         buildId = "BP4A.251205.006.S938BCZG1",
         fingerprint = "samsung/example",
         androidRelease = "16",


### PR DESCRIPTION
KernelSU is late-loaded as a runtime module on these Samsung targets and **nothing persists across reboot** — RKP pins `sys_call_table` read-only at EL2 and the bootloader is locked, so there is no persistent install mechanism. Today that means manually re-running the app after every power cycle.

### What this adds
- `BootReceiver`: on `BOOT_COMPLETED`, skips if the module is already active (`NativeProbe.isKernelSuActive()`), otherwise starts the service
- `BootInstallService`: low-priority **foreground dataSync service** that runs the existing standalone install path unattended; the notification mirrors install progress and the service stops itself at any terminal phase (`START_NOT_STICKY` — failures retry at next boot or from the UI)
- Shizuku mode is forced off for the duration of the run (it is generally unreachable right after boot) and restored in `onDestroy`
- Artifacts come from the **normal commit-pinned download flow** — no embedded payloads, no offline design

### Manifest
Adds `RECEIVE_BOOT_COMPLETED`, `FOREGROUND_SERVICE(+DATA_SYNC)`, `POST_NOTIFICATIONS`; declares the receiver (`exported=false`, protected system broadcast) and the service. One new string (`notification_channel_boot`).

### Stacks on #482
Without the 120 s `runHelper` watchdog from #482, a helper hanging during boot-time late-load would wedge an eternal foreground service.
