### PR TITLE
Add optional offline payload mode behind a build flag

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,6 +24,12 @@ android {
                 arguments += "-DANDROID_STL=none"
             }
         }
+
+        // Optional offline flavor: `./gradlew assembleRelease -PrmgOfflinePayloads=true`
+        // bundles payloads/targets-v3.json and payload artifacts from assets. The
+        // default (online) build requires no bundled payloads and behaves like upstream.
+        val offlinePayloads = (project.findProperty("rmgOfflinePayloads") as? String)?.toBooleanStrictOrNull() ?: false
+        buildConfigField("boolean", "OFFLINE_PAYLOADS", offlinePayloads.toString())
     }
 
     buildFeatures {

--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -15,8 +15,24 @@ data class VerifiedPayloads(
     val kernelSu: File,
 )
 
+/**
+ * Payload source repository.
+ *
+ * Two modes are supported at build time:
+ *  - Online (default): the original upstream implementation, unchanged — the
+ *    manifest and artifacts are fetched from the upstream payloads repository
+ *    pinned to the latest commit.
+ *  - Offline (opt-in via the `rmgOfflinePayloads` Gradle property): the
+ *    manifest and all artifacts are read from bundled assets
+ *    (`payloads/targets-v3.json` and `payloads/<payloadId>/...`), so no
+ *    network is required at runtime.
+ */
 class PayloadRepository(private val context: Context) {
     fun loadTargets(): List<TargetProfile> {
+        if (BuildConfig.OFFLINE_PAYLOADS) {
+            val bytes = context.assets.open(MANIFEST_ASSET).use { it.readBytes() }
+            return SupportManifest.parse(bytes).targets
+        }
         val commit = resolveMainCommit()
         val manifestBytes = downloadBytes(rawUrl(commit, "support/targets-v3.json"), MAX_MANIFEST_BYTES)
         return SupportManifest.parse(manifestBytes).targets.map { profile -> profile.copy(
@@ -60,28 +76,52 @@ class PayloadRepository(private val context: Context) {
     ): File {
         onProgress(context.getString(R.string.repo_downloading, label))
         val temporary = File(destination.parentFile, "${destination.name}.part")
-        val connection = open(artifact.url)
-        require(connection.contentLengthLong == -1L || connection.contentLengthLong == artifact.size) {
-            context.getString(R.string.repo_size_mismatch, label)
-        }
-        var total = 0L
-        connection.inputStream.use { input ->
-            FileOutputStream(temporary).use { output ->
-                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                while (true) {
-                    val count = input.read(buffer)
-                    if (count < 0) break
-                    total += count
-                    require(total <= artifact.size) {
-                        context.getString(R.string.repo_size_exceeded, label)
-                    }
-                    output.write(buffer, 0, count)
-                }
-                output.fd.sync()
+        if (BuildConfig.OFFLINE_PAYLOADS) {
+            require(artifact.url.startsWith(ASSET_PREFIX)) {
+                context.getString(R.string.repo_url_invalid)
             }
+            val source = context.assets.open(artifact.url.removePrefix(ASSET_PREFIX))
+            var total = 0L
+            source.use { input ->
+                FileOutputStream(temporary).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        total += count
+                        require(total <= artifact.size) {
+                            context.getString(R.string.repo_size_exceeded, label)
+                        }
+                        output.write(buffer, 0, count)
+                    }
+                    output.fd.sync()
+                }
+            }
+            require(total == artifact.size) { context.getString(R.string.repo_incomplete, label) }
+        } else {
+            val connection = open(artifact.url)
+            require(connection.contentLengthLong == -1L || connection.contentLengthLong == artifact.size) {
+                context.getString(R.string.repo_size_mismatch, label)
+            }
+            var total = 0L
+            connection.inputStream.use { input ->
+                FileOutputStream(temporary).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        total += count
+                        require(total <= artifact.size) {
+                            context.getString(R.string.repo_size_exceeded, label)
+                        }
+                        output.write(buffer, 0, count)
+                    }
+                    output.fd.sync()
+                }
+            }
+            connection.disconnect()
+            require(total == artifact.size) { context.getString(R.string.repo_incomplete, label) }
         }
-        connection.disconnect()
-        require(total == artifact.size) { context.getString(R.string.repo_incomplete, label) }
         if (destination.exists()) destination.delete()
         require(temporary.renameTo(destination)) {
             context.getString(R.string.repo_finalize_failed, label)
@@ -89,6 +129,8 @@ class PayloadRepository(private val context: Context) {
         onProgress(context.getString(R.string.repo_verified, label))
         return destination
     }
+
+    // ---- Online-only upstream helpers (upstream implementation, unchanged) ----
 
     private fun resolveMainCommit(): String {
         val response = downloadBytes(COMMIT_API_URL, MAX_COMMIT_RESPONSE_BYTES)
@@ -136,6 +178,8 @@ class PayloadRepository(private val context: Context) {
         }
 
     companion object {
+        private const val MANIFEST_ASSET = "payloads/targets-v3.json"
+        private const val ASSET_PREFIX = "asset://"
         private const val COMMIT_API_URL =
             "https://api.github.com/repos/BuSung-dev/Root-My-Galaxy-Payloads/git/ref/heads/main"
         private const val RAW_REPOSITORY =

--- a/gen-offline-manifest.ps1
+++ b/gen-offline-manifest.ps1
@@ -1,0 +1,83 @@
+# Generate the offline payload manifest (assets/payloads/targets-v3.json)
+# from the authoritative upstream manifest (support/targets-v3.json of
+# BuSung-dev/Root-My-Galaxy-Payloads).
+#
+# This script is a converter, not a second device database: every entry of the
+# upstream manifest is preserved as-is (payloadId, displayName, models,
+# kernelVersions, requiresFreshP0Session and any future optional fields).
+# Only the artifact URLs are rewritten to bundled-asset URLs and their sizes
+# are re-measured from the local files.
+#
+# Usage:
+#   1. Download the upstream manifest:
+#      https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/support/targets-v3.json
+#      and save it next to this script as upstream-targets-v3.json
+#   2. Place payload artifacts under app/src/main/assets/payloads/:
+#      - per-device exploit:  payloads/<payloadId>/cve-2026-43499-app.so
+#      - shared ksud builds:  payloads/ksud/<ksud filename from upstream URL>
+#   3. Run:  powershell -ExecutionPolicy Bypass -File gen-offline-manifest.ps1
+#
+# The script fails loudly when a referenced artifact is missing, instead of
+# silently producing a manifest that would fail at runtime.
+
+$ErrorActionPreference = "Stop"
+$root = $PSScriptRoot
+$base = Join-Path $root "app\src\main\assets\payloads"
+$upstreamManifestPath = Join-Path $root "upstream-targets-v3.json"
+$out = Join-Path $base "targets-v3.json"
+
+if (-not (Test-Path $upstreamManifestPath)) {
+    throw "Upstream manifest not found: $upstreamManifestPath`nDownload it from https://raw.githubusercontent.com/BuSung-dev/Root-My-Galaxy-Payloads/main/support/targets-v3.json"
+}
+
+$upstream = Get-Content $upstreamManifestPath -Raw | ConvertFrom-Json
+if ($upstream.schemaVersion -ne 3) {
+    throw "Unsupported upstream schemaVersion: $($upstream.schemaVersion) (expected 3)"
+}
+
+function Resolve-Asset([string]$url, [string]$payloadId) {
+    # Upstream artifact URL -> local bundled asset path.
+    # Current upstream formats (support/targets-v3.json on main):
+    #   .../artifacts/<payloadId>/cve-2026-43499-app.so
+    #   .../kernelsu/ksud-<name>
+    # The app-bundled flavor (historical app manifests) uses:
+    #   assets://payloads/<payloadId>/cve-2026-43499-app.so
+    #   assets://payloads/ksud/ksud-<name>
+    # Both are recognized so either manifest source converts cleanly.
+    if ($url -match '(?:kernelsu|ksud)/(ksud[^/]*)$') {
+        return @{ dir = "ksud"; file = $Matches[1] }
+    }
+    if ($url -match '(?:artifacts|payloads)/([^/]+)/cve-2026-43499-app\.so$') {
+        return @{ dir = $Matches[1]; file = "cve-2026-43499-app.so" }
+    }
+    throw "Unrecognized artifact URL for ${payloadId}: $url"
+}
+
+$entries = New-Object System.Collections.Generic.List[object]
+foreach ($p in $upstream.payloads) {
+    $exploitAsset = Resolve-Asset $p.exploit.url $p.payloadId
+    $ksudAsset = Resolve-Asset $p.kernelsu.url $p.payloadId
+
+    $exploitPath = Join-Path $base "$($exploitAsset.dir)\$($exploitAsset.file)"
+    $ksudPath = Join-Path $base "$($ksudAsset.dir)\$($ksudAsset.file)"
+    if (-not (Test-Path $exploitPath)) {
+        throw "Missing bundled exploit for $($p.payloadId): $exploitPath"
+    }
+    if (-not (Test-Path $ksudPath)) {
+        throw "Missing bundled ksud for $($p.payloadId): $ksudPath"
+    }
+
+    # Clone the original entry and touch only the artifact fields, so optional
+    # upstream metadata (requiresFreshP0Session, future fields) survives.
+    $entry = $p.PSObject.Copy()
+    $entry.exploit.url = "asset://payloads/$($exploitAsset.dir)/$($exploitAsset.file)"
+    $entry.exploit.size = (Get-Item $exploitPath).Length
+    $entry.kernelsu.url = "asset://payloads/$($ksudAsset.dir)/$($ksudAsset.file)"
+    $entry.kernelsu.size = (Get-Item $ksudPath).Length
+    $entries.Add($entry)
+}
+
+$manifest = [ordered]@{ schemaVersion = 3; payloads = $entries }
+$json = $manifest | ConvertTo-Json -Depth 8
+[System.IO.File]::WriteAllText($out, $json, [System.Text.UTF8Encoding]::new($false))
+Write-Host "WROTE $out with $($entries.Count) entries"


### PR DESCRIPTION
# Proposed replacement description — PR #570

> Draft only. Do not edit the GitHub PR until explicitly authorized.

---

**Title:** Add optional offline payload mode behind a build flag

Adds an opt-in offline payload mode behind a Gradle flag. The default build behaves exactly like upstream; the online flow is untouched.

## Usage

```sh
./gradlew assembleRelease -PrmgOfflinePayloads=true
```

When the flag is set, the manifest and payload binaries are read from bundled assets (`payloads/targets-v3.json`, `payloads/<payloadId>/…`), so no network is required at runtime.

## What changes

- **`PayloadRepository`** (`app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt`): a single `BuildConfig.OFFLINE_PAYLOADS` branch in `loadTargets()` and `downloadArtifact()`.
  - Online path (default): the upstream implementation, unchanged — GitHub manifest fetch, pinned-commit artifact URLs, `Content-Length` validation, streamed byte-count validation, explicit `disconnect()`.
  - Offline path: same pipeline served from assets via `asset://` URLs, with equivalent final-size validation.
- **`gen-offline-manifest.ps1`** (new): a converter, not a second device database. It reads the authoritative upstream manifest (`support/targets-v3.json` from the payloads repository, saved locally as `upstream-targets-v3.json`), clones each entry as-is (including `requiresFreshP0Session` and any future optional fields), rewrites only the artifact URLs to `asset://payloads/…`, and re-measures sizes from the local files. Recognizes the current upstream URL formats (`…/artifacts/<id>/cve-2026-43499-app.so`, `…/kernelsu/ksud-…`) and the app-bundled `assets://payloads/…` flavor. Missing upstream manifest or missing artifact files fail loudly.

## What does not change

- Default build: `OFFLINE_PAYLOADS=false`, no bundled payload assets required, online flow byte-for-byte upstream.
- Device matching, error strings, and both size-validation stages in online mode are identical to upstream.
- No new permissions, components, dependencies, UI, signing, or lint changes.

## Expected asset layout (offline builds)

```
app/src/main/assets/payloads/
├── targets-v3.json          # generated by gen-offline-manifest.ps1
├── <payloadId>/cve-2026-43499-app.so
└── ksud/ksud-<name>
```

## Verification

- `./gradlew assembleDebug` (online) — success; requires no `assets/payloads/` directory
- `./gradlew assembleDebug -PrmgOfflinePayloads=true` (offline) — success with payloads bundled
- `./gradlew testDebugUnitTest` — success
- Converter: 42/42 upstream entries converted; structural comparison shows the only diff vs upstream is artifact URL/size (by design); `requiresFreshP0Session` survives conversion (verified via property-copy round-trip on a manifest containing the field); 20/20 current `https://…/artifacts/…` URLs and all `assets://payloads/…` URLs parse correctly; missing artifacts fail with explicit per-file messages
