### PR TITLE
Support profiles that require a fresh P0 session

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
+++ b/app/src/main/java/dev/busung/s25uroot/InstallViewModel.kt
@@ -195,7 +195,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 appendLog(app.getString(R.string.log_download_verified))
 
                 setPhase(InstallPhase.Exploiting, app.getString(R.string.status_exploit_running))
-                executeExploit(payloads.exploit)
+                executeExploit(payloads.exploit, profile.requiresFreshP0Session)
 
                 setPhase(InstallPhase.LoadingKernelSu, app.getString(R.string.status_ksu_loading))
                 installKernelSu(payloads)
@@ -213,7 +213,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
     }
 
-    private suspend fun executeExploit(payload: File) {
+    private suspend fun executeExploit(payload: File, requiresFreshP0Session: Boolean) {
         val shizuku = shizukuEnabled()
         val logFile = if (shizuku) File(SHIZUKU_LOG_PATH) else File(app.filesDir, "exploit.log")
         if (shizuku) {
@@ -227,11 +227,17 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
         val logPrefix = mutableState.value.log
         val bootToken = currentBootToken()
+        val cachedP0Offset = if (requiresFreshP0Session) null else cachedP0Offset(bootToken)
         val process = if (shizuku) {
             val stagedPayload = shizukuStage(payload, SHIZUKU_PAYLOAD_PATH, "755")
             ShizukuController.exec(
                 arrayOf("/system/bin/sh", "-c", "true"),
-                shizukuEnvironment(bootToken, stagedPayload.absolutePath, helper.absolutePath),
+                shizukuEnvironment(
+                    stagedPayload.absolutePath,
+                    helper.absolutePath,
+                    requiresFreshP0Session,
+                    cachedP0Offset,
+                ),
             )
         } else {
             val processBuilder = ProcessBuilder(
@@ -241,12 +247,9 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 helper.absolutePath,
                 logFile.absolutePath,
             ).redirectErrorStream(true)
-            processBuilder.environment().apply {
-                put("EXPLOIT_ATTEMPTS", EXPLOIT_ATTEMPTS)
-                put("P0_ATTEMPT_TIMEOUT_SEC", P0_ATTEMPT_TIMEOUT_SEC)
-                put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", EXPLOIT_ATTEMPT_TIMEOUT_SEC)
-                cachedP0Offset(bootToken)?.let { put(P0_OFFSET_ENV, it) }
-            }
+            processBuilder.environment().putAll(
+                exploitEnvironment(requiresFreshP0Session, cachedP0Offset),
+            )
             processBuilder.start()
         }
         val captured = StringBuilder()
@@ -266,14 +269,16 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             while (process.isAlive) {
                 val rawLog = readLog()
                 if (rawLog != lastRawLog) {
-                    cacheP0Offset(bootToken, rawLog)
+                    if (!requiresFreshP0Session) cacheP0Offset(bootToken, rawLog)
                     publishExploitLog(logPrefix, rawLog)
                     lastRawLog = rawLog
                     lastProgressAt = SystemClock.elapsedRealtime()
                 }
                 val now = SystemClock.elapsedRealtime()
-                require(now - lastProgressAt < EXPLOIT_STALL_MILLIS) {
-                    app.getString(R.string.error_exploit_stalled)
+                if (!requiresFreshP0Session) {
+                    require(now - lastProgressAt < EXPLOIT_STALL_MILLIS) {
+                        app.getString(R.string.error_exploit_stalled)
+                    }
                 }
                 require(now - startedAt < EXPLOIT_TOTAL_MILLIS) {
                     app.getString(R.string.error_exploit_timeout)
@@ -283,7 +288,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
             val exitCode = process.waitFor()
             val rawLog = readLog()
-            cacheP0Offset(bootToken, rawLog)
+            if (!requiresFreshP0Session) cacheP0Offset(bootToken, rawLog)
             publishExploitLog(logPrefix, rawLog)
             // Both transports drain into `captured` during the poll loop, so
             // this never blocks on a child still holding the pipe open.
@@ -435,16 +440,16 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
     }
 
     private fun shizukuEnvironment(
-        bootToken: String?,
         payloadPath: String,
         helperPath: String,
+        requiresFreshP0Session: Boolean,
+        cachedP0Offset: String?,
     ): Array<String> = buildList {
-        add("EXPLOIT_ATTEMPTS=$EXPLOIT_ATTEMPTS")
-        add("P0_ATTEMPT_TIMEOUT_SEC=$P0_ATTEMPT_TIMEOUT_SEC")
-        add("EXPLOIT_ATTEMPT_TIMEOUT_SEC=$EXPLOIT_ATTEMPT_TIMEOUT_SEC")
+        exploitEnvironment(requiresFreshP0Session, cachedP0Offset).forEach { (name, value) ->
+            add("$name=$value")
+        }
         add("CVE43499_ROOT_HELPER=$helperPath")
         add("LD_PRELOAD=$payloadPath")
-        cachedP0Offset(bootToken)?.let { add("$P0_OFFSET_ENV=$it") }
     }.toTypedArray()
 
     /**
@@ -571,6 +576,18 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private val P0_OFFSET_PATTERN = Regex(
             "slide-kaslr-ok[^\\n]*slide=([0-9a-fA-F]{16})",
         )
+
+        internal fun exploitEnvironment(
+            requiresFreshP0Session: Boolean,
+            cachedP0Offset: String?,
+        ): Map<String, String> = buildMap {
+            put("EXPLOIT_ATTEMPTS", if (requiresFreshP0Session) "1" else EXPLOIT_ATTEMPTS)
+            if (!requiresFreshP0Session) {
+                put("P0_ATTEMPT_TIMEOUT_SEC", P0_ATTEMPT_TIMEOUT_SEC)
+                put("EXPLOIT_ATTEMPT_TIMEOUT_SEC", EXPLOIT_ATTEMPT_TIMEOUT_SEC)
+                cachedP0Offset?.let { put(P0_OFFSET_ENV, it) }
+            }
+        }
 
         private fun stripAnsi(value: String): String = ANSI_ESCAPE.replace(value, "").replace("\r", "")
     }

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -13,6 +13,7 @@ data class TargetProfile(
     val displayName: String,
     val models: Set<String>,
     val kernelVersions: Set<String>,
+    val requiresFreshP0Session: Boolean = false,
     val exploit: RemoteArtifact,
     val kernelSu: RemoteArtifact,
 ) {
@@ -58,6 +59,7 @@ data class SupportManifest(
                             displayName = payload.getString("displayName"),
                             models = payload.getJSONArray("models").strings(),
                             kernelVersions = payload.getJSONArray("kernelVersions").strings(),
+                            requiresFreshP0Session = payload.optBoolean("requiresFreshP0Session", false),
                             exploit = RemoteArtifact(
                                 url = exploit.getString("url"),
                                 size = exploit.getLong("size"),

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -1,5 +1,6 @@
 package dev.busung.s25uroot
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -24,6 +25,16 @@ class TargetProfileTest {
     fun rejectsUnlistedModelOrKernelVersion() {
         assertFalse(profile.matches(snapshot("SM-S928B", "6.6.98-android15-8-build")))
         assertFalse(profile.matches(snapshot("SM-S938N", "6.6.102-android15-8-build")))
+    }
+
+    @Test
+    fun freshP0SessionRunsOnceWithoutCacheOrShortTimeoutOverrides() {
+        val freshProfile = profile.copy(requiresFreshP0Session = true)
+
+        assertEquals(
+            mapOf("EXPLOIT_ATTEMPTS" to "1"),
+            InstallViewModel.exploitEnvironment(freshProfile.requiresFreshP0Session, "0x1a0000"),
+        )
     }
 
     private fun snapshot(


### PR DESCRIPTION
## Summary

- add the optional `requiresFreshP0Session` target-profile flag
- skip cached slide data and the short legacy timeout overrides for marked profiles
- use one payload-native attempt in both direct and Shizuku paths while keeping the overall deadline

The flag defaults to `false`, so existing profiles keep their current behavior.

Companion profile: BuSung-dev/Root-My-Galaxy-Payloads#303

## Validation

- `./gradlew :app:testDebugUnitTest :app:assembleDebug --no-daemon --no-parallel --max-workers=2`
- device-tested with the matching Galaxy A55 payload on `SM-A556E` / `A556EXXUEDZE4` through Shizuku
