### PR TITLE
Resolve the payload profile by exact kernel release when available

### DIFF
--- a/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
+++ b/app/src/main/java/dev/busung/s25uroot/PayloadRepository.kt
@@ -26,7 +26,7 @@ class PayloadRepository(private val context: Context) {
     }
 
     fun resolveTarget(snapshot: DeviceSnapshot): TargetProfile = loadTargets()
-        .firstOrNull { it.matches(snapshot) }
+        .resolveFor(snapshot)
         ?: error(context.getString(R.string.repo_no_profile))
 
     fun resolveTarget(profileId: String): TargetProfile = loadTargets()

--- a/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
+++ b/app/src/main/java/dev/busung/s25uroot/SupportManifest.kt
@@ -37,6 +37,18 @@ data class TargetProfile(
         get() = kernelVersions.joinToString()
 }
 
+/**
+ * Picks the profile for [snapshot].
+ *
+ * An exact full kernel-release match wins, so regional builds that share a
+ * model and the three-part kernel version (for example `SM-S9360` ZCS vs ZHS)
+ * resolve to the profile that documents their build. Profiles that only list a
+ * three-part version keep the legacy first-match behaviour.
+ */
+fun List<TargetProfile>.resolveFor(snapshot: DeviceSnapshot): TargetProfile? =
+    firstOrNull { it.matches(snapshot) && snapshot.kernelRelease in it.kernelVersions }
+        ?: firstOrNull { it.matches(snapshot) }
+
 data class SupportManifest(
     val schemaVersion: Int,
     val targets: List<TargetProfile>,

--- a/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
+++ b/app/src/test/java/dev/busung/s25uroot/TargetProfileTest.kt
@@ -1,6 +1,8 @@
 package dev.busung.s25uroot
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -24,6 +26,41 @@ class TargetProfileTest {
     fun rejectsUnlistedModelOrKernelVersion() {
         assertFalse(profile.matches(snapshot("SM-S928B", "6.6.98-android15-8-build")))
         assertFalse(profile.matches(snapshot("SM-S938N", "6.6.102-android15-8-build")))
+    }
+
+    @Test
+    fun prefersProfileWithExactKernelRelease() {
+        val zcs = profile.copy(
+            profileId = "pa2q-S9360ZCSCCZG1",
+            models = setOf("SM-S9360"),
+            kernelVersions = setOf("6.6.98"),
+        )
+        val zhs = profile.copy(
+            profileId = "pa2q-S9360ZHSCCZG1",
+            models = setOf("SM-S9360"),
+            kernelVersions = setOf(
+                "6.6.98",
+                "6.6.98-android15-8-pd6ff1cd-abogkiS9360ZHSCCZG1-4k",
+            ),
+        )
+
+        val selected = listOf(zcs, zhs)
+            .resolveFor(snapshot("SM-S9360", "6.6.98-android15-8-pd6ff1cd-abogkiS9360ZHSCCZG1-4k"))
+
+        assertEquals("pa2q-S9360ZHSCCZG1", selected?.profileId)
+    }
+
+    @Test
+    fun fallsBackToThreePartMatch() {
+        val selected = listOf(profile)
+            .resolveFor(snapshot("SM-S931B", "6.6.98-android15-8-build-a"))
+
+        assertEquals("galaxy-s25-series-kernel-6.6.98", selected?.profileId)
+    }
+
+    @Test
+    fun returnsNullWhenNothingMatches() {
+        assertNull(listOf(profile).resolveFor(snapshot("SM-S928B", "6.6.98-android15-8-build-a")))
     }
 
     private fun snapshot(


### PR DESCRIPTION
## AI authorship

This PR was prepared with the assistance of an AI agent. The change was
validated with the repository's own unit tests on device snapshots
(`./gradlew :app:testDebugUnitTest --tests "dev.busung.s25uroot.TargetProfileTest"`
— 5/5 pass) and on hardware for the underlying issue.

## Summary

`PayloadRepository.resolveTarget` returns the first profile that matches the
device model and the **three-part** kernel version. Two regional builds of the
same model can share that version, and then the first entry in the feed wins.

Concrete case: `SM-S9360` has `pa2q-S9360ZCSCCZG1` (China, `p5a696e2` GKI) and
`pa2q-S9360ZHSCCZG1` (Hong Kong, `pd6ff1cd` GKI), both listed as `6.6.98`. A
ZHS device therefore runs the ZCS payload and fails in `phys step cache gate`
— that is #632, which also produced a kernel panic in one run (`Comm:
cve43499-run`).

This PR adds `List<TargetProfile>.resolveFor(snapshot)`, which prefers the
profile whose `kernelVersions` contain the exact `uname -r` release
(`snapshot.kernelRelease`) and falls back to the existing first-match
behaviour. Feeds that only carry three-part versions are unaffected.

```kotlin
fun List<TargetProfile>.resolveFor(snapshot: DeviceSnapshot): TargetProfile? =
    firstOrNull { it.matches(snapshot) && snapshot.kernelRelease in it.kernelVersions }
        ?: firstOrNull { it.matches(snapshot) }
```

The feed side is a separate PR against `BuSung-dev/Root-My-Galaxy-Payloads`
(#318): the two `pa2q` entries list their exact kernel releases in addition to
`6.6.98`, and `support/README.md` documents the rule. Older clients keep the
three-part string and behave exactly as today.

## Tests

`TargetProfileTest` gains three cases:

- `prefersProfileWithExactKernelRelease` — ZCS vs ZHS, exact release selects ZHS
- `fallsBackToThreePartMatch` — shared S25 profile without an exact release
- `returnsNullWhenNothingMatches`

## Notes

- No behaviour change for any device whose profile only lists a three-part
  kernel version.
- The profile itself (`pa2q-S9360ZHSCCZG1`) is in payloads PR #318.
